### PR TITLE
API overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pcap"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 description = "A packet capture API around pcap/wpcap"
 keywords = ["pcap", "packet", "sniffing"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ path = "examples/getdevices.rs"
 name = "easylisten"
 path = "examples/easylisten.rs"
 
+[[example]]
+name = "savefile"
+path = "examples/savefile.rs"
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ or `C:\Rust\bin\rustlib\i686-pc-windows-gnu\lib\` on 32 bit.
 
 ## Linux
 
-On Debian based Linux, install `libpcap-dev`.
+On Debian based Linux, install `libpcap-dev`. If not running as root, you need to set capabilities like so: ```sudo setcap cap_net_raw,cap_net_admin=eip path/to/bin```
 
 ## Mac OS X
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # pcap [![Build status](https://api.travis-ci.org/ebfull/pcap.svg)](https://travis-ci.org/ebfull/pcap) [![Crates.io](https://img.shields.io/crates/v/pcap.svg)](https://crates.io/crates/pcap) #
 
-[Documentation](http://www.rust-ci.org/ebfull/pcap/doc/pcap/)
+### [Documentation](http://www.rust-ci.org/ebfull/pcap/doc/pcap/)
 
 This is a **Rust language** crate for accessing the packet sniffing capabilities of pcap (or wpcap on Windows).
-It is limited in functionality, so if you need anything feel free to post an issue or submit a pull request!
+If you need anything feel free to post an issue or submit a pull request!
 
 ## Features:
 
 * List devices
-* Open capture handle on a device or file
+* Open capture handle on a device or savefiles
+* Get packets from the capture handle
+* Filter packets using BPF programs
 * List/set/get datalink link types
 * Configure some parameters like promiscuity and buffer length
-* Get packets from the capture handle, of course!
+* Write packets to savefiles
+* Inject packets into an interface
 
 See examples for usage.
 

--- a/examples/easylisten.rs
+++ b/examples/easylisten.rs
@@ -5,7 +5,7 @@ fn main() {
     let default = pcap::Device::lookup().unwrap();
 
     // open a capture handle from it
-    let mut cap = pcap::Capture::from_device(default).unwrap();
+    let mut cap = pcap::Capture::from_device(default).unwrap().open().unwrap();
 
     // get a packet and print its bytes
     println!("{:?}", cap.next());

--- a/examples/easylisten.rs
+++ b/examples/easylisten.rs
@@ -2,10 +2,7 @@ extern crate pcap;
 
 fn main() {
     // get the default Device
-    let default = pcap::Device::lookup().unwrap();
-
-    // open a capture handle from it
-    let mut cap = pcap::Capture::from_device(default).unwrap().open().unwrap();
+    let mut cap = pcap::Device::lookup().unwrap().open().unwrap();
 
     // get a packet and print its bytes
     println!("{:?}", cap.next());

--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -6,13 +6,11 @@ fn main() {
         println!("Found device! {:?}", device);
 
         // now you can create a Capture with this Device if you want.
-        let mut cap = pcap::Capture::from_device(device).unwrap().open().unwrap();
+        let mut cap = device.open().unwrap();
 
         // get a packet from this capture
-        {
-        	let packet = cap.next();
+        let packet = cap.next();
 
-        	println!("got a packet! {:?}", packet);
-        }
+        println!("got a packet! {:?}", packet);
     }
 }

--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -6,7 +6,7 @@ fn main() {
         println!("Found device! {:?}", device);
 
         // now you can create a Capture with this Device if you want.
-        let mut cap = pcap::Capture::from_device(device).unwrap();
+        let mut cap = pcap::Capture::from_device(device).unwrap().open().unwrap();
 
         // get a packet from this capture
         {

--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -2,7 +2,7 @@ extern crate pcap;
 
 fn main() {
     // list all of the devices pcap tells us are available
-    for device in pcap::Devices::list_all().unwrap() {
+    for device in pcap::Device::list().unwrap() {
         println!("Found device! {:?}", device);
 
         // now you can create a Capture with this Device if you want.

--- a/examples/listenlocalhost.rs
+++ b/examples/listenlocalhost.rs
@@ -3,7 +3,7 @@ extern crate pcap;
 fn main() {
     // listen on the device named "any", which is only available on Linux. On Windows you may need to
     // use Devices::list_all() and listen to each or the specific ones you need
-    let mut cap = pcap::Capture::from_device("any").unwrap();
+    let mut cap = pcap::Capture::from_device("any").unwrap().open().unwrap();
 
     // filter out all packets that don't have 127.0.0.1 as a source or destination.
     cap.filter("host 127.0.0.1").unwrap();

--- a/examples/listenlocalhost.rs
+++ b/examples/listenlocalhost.rs
@@ -1,8 +1,8 @@
 extern crate pcap;
 
 fn main() {
-    // listen on the device named "any", which is only available on Linux. On Windows you may need to
-    // use Devices::list_all() and listen to each or the specific ones you need
+    // listen on the device named "any", which is only available on Linux. This is only for
+    // demonstration purposes.
     let mut cap = pcap::Capture::from_device("any").unwrap().open().unwrap();
 
     // filter out all packets that don't have 127.0.0.1 as a source or destination.

--- a/examples/savefile.rs
+++ b/examples/savefile.rs
@@ -1,0 +1,31 @@
+extern crate pcap;
+
+use pcap::*;
+
+fn main() {
+	{
+		// open capture from default device
+		let mut cap = Capture::from_device(Device::lookup().unwrap()).unwrap().open().unwrap();
+
+		// open savefile using the capture
+		let mut savefile = cap.savefile("test.pcap").unwrap();
+
+		// get a packet from the interface
+		let p = cap.next().unwrap();
+
+		// print the packet out
+		println!("packet received on network: {:?}", p);
+
+		// write the packet to the savefile
+		savefile.write(&p);
+	}
+
+	// open a new capture from the test.pcap file we wrote to above
+	let mut cap = Capture::from_file("test.pcap").unwrap();
+
+	// get a packet
+	let p = cap.next().unwrap();
+
+	// print that packet out -- it should be the same as the one we printed above
+	println!("packet obtained from file: {:?}", p);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod raw;
 mod unique;
 
 const PCAP_ERROR_NOT_ACTIVATED: i32 = -3;
+const PCAP_ERRBUF_SIZE: usize = 256;
 
 /// An error received from pcap
 #[derive(Debug)]
@@ -76,7 +77,7 @@ impl Device {
     /// Returns the default Device suitable for captures according to pcap_lookupdev,
     /// or an error from pcap.
     pub fn lookup() -> Result<Device, Error> {
-        let mut errbuf = [0i8; 256];
+        let mut errbuf = [0i8; PCAP_ERRBUF_SIZE];
 
         unsafe {
             let default_name = raw::pcap_lookupdev(errbuf.as_mut_ptr());
@@ -95,7 +96,7 @@ impl Device {
     /// Returns a vector of `Device`s known by pcap via pcap_findalldevs.
     pub fn list() -> Result<Vec<Device>, Error> {
         unsafe {
-            let mut errbuf = [0i8; 256];
+            let mut errbuf = [0i8; PCAP_ERRBUF_SIZE];
             let mut dev_buf: *mut raw::Struct_pcap_if = ptr::null_mut();
             let mut ret = vec![];
 
@@ -242,7 +243,7 @@ impl Capture<All> {
     pub fn from_device<D: Into<Device>>(device: D) -> Result<Capture<Inactive>, Error> {
         let device: Device = device.into();
         let name = CString::new(device.name).unwrap();
-        let mut errbuf = [0i8; 256];
+        let mut errbuf = [0i8; PCAP_ERRBUF_SIZE];
 
         unsafe {
             let handle = raw::pcap_create(name.as_ptr(), errbuf.as_mut_ptr());
@@ -260,7 +261,7 @@ impl Capture<All> {
     /// Opens an offline capture handle from a pcap dump file, given a path.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Capture<Offline>, Error> {
         let name = CString::new(path.as_ref().to_str().unwrap()).unwrap();
-        let mut errbuf = [0i8; 256];
+        let mut errbuf = [0i8; PCAP_ERRBUF_SIZE];
 
         unsafe {
             let handle = raw::pcap_open_offline(name.as_ptr(), errbuf.as_mut_ptr());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,17 +3,15 @@ extern crate libc;
 use unique::Unique;
 use std::ptr::{self};
 use std::ffi::{CStr,CString};
-use std::default::Default;
 use std::path::Path;
 use std::slice;
 use std::ops::Deref;
 use std::str;
 use std::fmt;
-use std::convert::From;
+use self::Error::*;
+
 mod raw;
 mod unique;
-
-use self::Error::*;
 
 const PCAP_ERROR_NOT_ACTIVATED: i32 = -3;
 
@@ -209,7 +207,7 @@ impl CaptureBuilder {
     }
 
     /// Open a `Capture` with this `CaptureBuilder` with the given device. You can
-    /// provide a `Device` or an &str name of the device/source you would like to open.
+    /// provide a `Device` or an `&str` name of the device/source you would like to open.
     pub fn open<D: Into<Device>>(&self, device: D) -> Result<Capture, Error> {
         let device: Device = device.into();
         let name = CString::new(device.name).unwrap();
@@ -299,8 +297,8 @@ impl<'b> Deref for Packet<'b> {
     }
 }
 
-impl<'a> std::fmt::Debug for Packet<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+impl<'a> fmt::Debug for Packet<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         self.deref().fmt(f)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,9 +155,12 @@ impl Device {
     }
 }
 
-impl AsRef<str> for Device {
-    fn as_ref(&self) -> &str {
-        &*self.name
+impl<'a> Into<Device> for &'a str {
+    fn into(self) -> Device {
+        Device {
+            name: self.into(),
+            desc: None
+        }
     }
 }
 
@@ -207,8 +210,9 @@ impl CaptureBuilder {
 
     /// Open a `Capture` with this `CaptureBuilder` with the given device. You can
     /// provide a `Device` or an &str name of the device/source you would like to open.
-    pub fn open<D: AsRef<str>>(&self, device: D) -> Result<Capture, Error> {
-        let name = CString::new(device.as_ref()).unwrap();
+    pub fn open<D: Into<Device>>(&self, device: D) -> Result<Capture, Error> {
+        let device: Device = device.into();
+        let name = CString::new(device.name).unwrap();
         // TODO: handle errors better throughout this library
         let mut errbuf = [0i8; 256];
 
@@ -313,7 +317,7 @@ impl Capture {
     ///
     /// You can provide this a `Device` from `Devices::list_all()` or an `&str` name of
     /// the device such as "any" on Linux.
-    pub fn from_device<D: AsRef<str>>(device: D) -> Result<Capture, Error> {
+    pub fn from_device<D: Into<Device>>(device: D) -> Result<Capture, Error> {
         CaptureBuilder::new().open(device)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ extern crate libc;
 
 use unique::Unique;
 use std::marker::PhantomData;
-use std::ptr::{self};
+use std::ptr;
 use std::ffi::{CStr,CString};
 use std::path::Path;
 use std::slice;
@@ -66,7 +66,7 @@ impl From<str::Utf8Error> for Error {
 }
 
 #[derive(Debug)]
-/// A network device as returned from `Devices::list_all()`.
+/// A network device name and (potentially) pcap's description of it.
 pub struct Device {
     pub name: String,
     pub desc: Option<String>
@@ -92,7 +92,7 @@ impl Device {
         }
     }
 
-    /// Returns a vector of `Device`s known by pcap.
+    /// Returns a vector of `Device`s known by pcap via pcap_findalldevs.
     pub fn list() -> Result<Vec<Device>, Error> {
         unsafe {
             let mut errbuf = [0i8; 256];
@@ -139,7 +139,10 @@ impl<'a> Into<Device> for &'a str {
     }
 }
 
-/// This is a datalink link type returned from pcap.
+/// This is a datalink link type.
+///
+/// As an example, `Linktype(1)` is ethernet. A full list of linktypes is available
+/// [here](http://www.tcpdump.org/linktypes.html).
 #[derive(Debug)]
 pub struct Linktype(pub i32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,6 +457,25 @@ impl<T: Activated> Capture<T> {
     }
 }
 
+impl Capture<Active> {
+    /// Sends a packet over this capture handle's interface, returning the number
+    /// of bytes written.
+    pub fn sendpacket<'a>(&mut self, buf: &'a [u8]) -> Result<usize, Error> {
+        unsafe {
+            let written = raw::pcap_inject(*self.handle, buf.as_ptr() as *const libc::types::common::c95::c_void, buf.len() as libc::types::os::arch::c95::size_t);
+
+            match written {
+                -1 => {
+                    return Error::new(raw::pcap_geterr(*self.handle));
+                },
+                _ => {
+                    Ok(written as usize)
+                }
+            }
+        }
+    }
+}
+
 impl<T> Drop for Capture<T> {
     fn drop(&mut self) {
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,11 +194,6 @@ pub enum Active {}
 /// Implements `Activated`.
 pub enum Offline {}
 
-// we do this because we cannot do impl<T> Capture<T> and provide specific return results
-// without tripping up type ambiguities at the callsite.
-#[doc(hidden)]
-pub enum All {}
-
 trait Activated {}
 
 impl Activated for Active {}
@@ -237,7 +232,7 @@ pub struct Capture<T> {
     _marker: PhantomData<T>
 }
 
-impl Capture<All> {
+impl Capture<()> {
     /// Opens a capture handle for a device. The handle is inactive, but can be activated
     /// via `.open()`. You can pass a `Device` or an `&str` device name here.
     pub fn from_device<D: Into<Device>>(device: D) -> Result<Capture<Inactive>, Error> {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,6 @@
 extern crate pcap;
 
-use pcap::Capture;
+use pcap::{Offline, Capture};
 use std::path::Path;
 
 #[test]
@@ -15,7 +15,7 @@ fn read_packet_with_truncated_data() {
     assert_eq!(capture.next().unwrap().len(), 20);
 }
 
-fn capture_from_test_file(file_name: &str) -> Capture {
+fn capture_from_test_file(file_name: &str) -> Capture<Offline> {
     let path = Path::new("tests/data/").join(file_name);
     Capture::from_file(path).unwrap()
 }


### PR DESCRIPTION
This is a WIP branch overhauling this library's API to better approximate the behavior of pcap, so that adding pcap_dump (#7) support makes more sense. Here are the motivations:

* We can't only return `&[u8]` from `next()` anymore because `pcap_dump` will need the packet headers when we "pipe" packets to it. So, we return a `Packet<'_>` structure which contains the headers and dereferences to the packet contents. (Still no allocations!)
* `AsRef<str>` is kind of confusing to new users, so now we do `Into<Device>` which `&str` implements.
* The CaptureBuilder pattern is a bit ugly. There are things we can only do with inactive captures (change settings). There are things we can only do with live captures (inject packets). There are things we can't do with dead captures (read packets). There are things we can only do with active captures (datalink lists, etc.) but not dead captures. I've decided to remove `CaptureBuilder` and expose everything into `Capture` using phantom types like `Capture<Inactive>`, `Capture<Active>`, and `Capture<Offline>`. This should allow us to enforce compile-time invariants over the API.
* I removed the `Devices` iterator because, realistically, there's no reason to pollute the API with this, and very little performance gain in the best case scenario. So instead, use `Device::list()` to get a `Vec<Device>`.

Further changes may be necessary to get pcap_dump functionality working nicely, or I might have to abandon this branch if the approach is too complicated or faulty in some way.

Fixes #7, Fixes #8