### PR TITLE
Distinguish between errors, timeouts, and EOF in `pcap::Capture.next()`

### DIFF
--- a/examples/listenlocalhost.rs
+++ b/examples/listenlocalhost.rs
@@ -8,7 +8,7 @@ fn main() {
     // filter out all packets that don't have 127.0.0.1 as a source or destination.
     cap.filter("host 127.0.0.1").unwrap();
 
-    while let Some(packet) = cap.next() {
+    while let Ok(packet) = cap.next() {
     	println!("got packet! {:?}", packet);
     }
 }


### PR DESCRIPTION
Previously, `pcap::Capture.next()` only handled one of the four possible return codes from `pcap_next_ex()`: reading a packet successfully.

From `man 3 pcap_next_ex`:

> RETURN VALUE
>    pcap_next_ex() returns 1 if the packet was read without problems, 0 if packets are being read from a live capture, and the timeout expired, -1 if an error occurred while reading the packet, and -2 if packets are being read from a ``savefile'', and there are no more packets to read from the savefile. If -1 is returned, pcap_geterr() or pcap_perror() may be called with p as an argument to fetch or display the error text.

This means previously there was no way to distinguish between probably harmless conditions like a timeout or end of the file and an error reading the packet.

This patch exposes all of these conditions through the `Error` enum, similar to `std::io::Error` and `std::io::ErrorKind`.