### PR TITLE
Add stats (received/dropped packets) to Capture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ path = "examples/easylisten.rs"
 name = "savefile"
 path = "examples/savefile.rs"
 
+[[example]]
+name = "getstatistics"
+path = "examples/getstatistics.rs"

--- a/examples/getstatistics.rs
+++ b/examples/getstatistics.rs
@@ -1,0 +1,12 @@
+extern crate pcap;
+
+fn main() {
+    // get the default Device
+    let mut cap = pcap::Device::lookup().unwrap().open().unwrap();
+
+    // get 10 packets
+    for _ in 0..10 {
+      cap.next().ok();
+    }
+    println!("{:?}", cap.stats());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ impl<'b> Deref for Packet<'b> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Stat {
     received: u32,
     dropped: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,13 @@ impl<'b> Deref for Packet<'b> {
     }
 }
 
+#[derive(Debug)]
+pub struct Stat {
+    received: u32,
+    dropped: u32,
+    if_dropped: u32
+}
+
 /// Phantom type representing an inactive capture handle.
 pub enum Inactive {}
 /// Phantom type representing an active capture handle.
@@ -556,6 +563,23 @@ impl<T: Activated + ?Sized> Capture<T> {
 
             raw::pcap_freecode(&mut bpf_program);
             Ok(())
+        }
+    }
+
+    pub fn stats(&mut self) -> Result<Stat, Error> {
+        unsafe {
+            let mut stats: raw::Struct_pcap_stat =
+                raw::Struct_pcap_stat {ps_recv: 0, ps_drop: 0, ps_ifdrop: 0};
+
+            if -1 == raw::pcap_stats(*self.handle, &mut stats) {
+                return Error::new(raw::pcap_geterr(*self.handle));
+            }
+
+            Ok(Stat {
+                received: stats.ps_recv,
+                dropped: stats.ps_drop,
+                if_dropped: stats.ps_ifdrop
+            })
         }
     }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -723,8 +723,8 @@ extern "C" {
     pub fn pcap_next_ex(arg1: *mut pcap_t, arg2: *mut *mut Struct_pcap_pkthdr,
                         arg3: *mut *const u_char) -> ::libc::c_int;
     // pub fn pcap_breakloop(arg1: *mut pcap_t) -> ();
-    // pub fn pcap_stats(arg1: *mut pcap_t, arg2: *mut Struct_pcap_stat)
-    //  -> ::libc::c_int;
+    pub fn pcap_stats(arg1: *mut pcap_t, arg2: *mut Struct_pcap_stat)
+     -> ::libc::c_int;
     pub fn pcap_setfilter(arg1: *mut pcap_t, arg2: *mut Struct_bpf_program)
      -> ::libc::c_int;
     // pub fn pcap_setdirection(arg1: *mut pcap_t, arg2: pcap_direction_t)
@@ -808,4 +808,3 @@ extern {
     pub fn pcap_set_rfmon(arg1: *mut pcap_t, arg2: ::libc::c_int)
      -> ::libc::c_int;
 }
-


### PR DESCRIPTION
This PR implements a stats fn in Capture. It uses pcap_stats. An example is added to show its use.

