### PR TITLE
make members of Stat struct public

### DIFF
--- a/examples/getstatistics.rs
+++ b/examples/getstatistics.rs
@@ -8,5 +8,6 @@ fn main() {
     for _ in 0..10 {
       cap.next().ok();
     }
-    println!("{:?}", cap.stats());
+    let stats = cap.stats().unwrap();
+    println!("Received: {}, dropped: {}, if_dropped: {}", stats.received, stats.dropped, stats.if_dropped);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,9 +267,9 @@ impl<'b> Deref for Packet<'b> {
 
 #[derive(Debug, Clone, Copy)]
 pub struct Stat {
-    received: u32,
-    dropped: u32,
-    if_dropped: u32
+    pub received: u32,
+    pub dropped: u32,
+    pub if_dropped: u32
 }
 
 /// Phantom type representing an inactive capture handle.


### PR DESCRIPTION
I forgot to make the members of the struct Stat public which prevents use of the statistics. This PR makes all members public