### PR TITLE
Implement AsRawFd for Capture for pcap_fileno ffi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ use std::mem::transmute;
 use std::str;
 use std::fmt;
 use self::Error::*;
+use std::os::unix::io::{RawFd, AsRawFd};
 
 pub use raw::PacketHeader;
 
@@ -596,6 +597,23 @@ impl Capture<Active> {
                 },
                 _ => {
                     Ok(())
+                }
+            }
+        }
+    }
+}
+
+impl AsRawFd for Capture<Active> {
+    fn as_raw_fd(&self) -> RawFd {
+        unsafe {
+            let fd = raw::pcap_fileno(*self.handle);
+
+            match fd {
+                -1 => {
+                    panic!("Unable to get file descriptor for live capture");
+                },
+                fd => {
+                    fd
                 }
             }
         }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -770,7 +770,7 @@ extern "C" {
     // pub fn pcap_major_version(arg1: *mut pcap_t) -> ::libc::c_int;
     // pub fn pcap_minor_version(arg1: *mut pcap_t) -> ::libc::c_int;
     // pub fn pcap_file(arg1: *mut pcap_t) -> *mut FILE;
-    // pub fn pcap_fileno(arg1: *mut pcap_t) -> ::libc::c_int;
+    pub fn pcap_fileno(arg1: *mut pcap_t) -> ::libc::c_int;
     pub fn pcap_dump_open(arg1: *mut pcap_t, arg2: *const ::libc::c_char)
      -> *mut pcap_dumper_t;
     // pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE)


### PR DESCRIPTION
The `AsRawFd` trait does not return a Result. However, the Capture
struct tracks the state of the capture. According to man, `pcap_fileno`
will should only return -1 for an offline/inactive capture. Thus, we
should never panic.