### PR TITLE
Conditional compile unix specific features for Windows users.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ use std::mem::transmute;
 use std::str;
 use std::fmt;
 use self::Error::*;
+#[cfg(not(windows))]
 use std::os::unix::io::{RawFd, AsRawFd};
 
 pub use raw::PacketHeader;
@@ -603,6 +604,7 @@ impl Capture<Active> {
     }
 }
 
+#[cfg(not(windows))]
 impl AsRawFd for Capture<Active> {
     fn as_raw_fd(&self) -> RawFd {
         unsafe {


### PR DESCRIPTION
This patch adds a conditional compilation to the RawFd and AsRawFd
features that are only available in Unix.