### PR TITLE
Add a 'Dead' capture type 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -715,26 +715,6 @@ impl Capture<Dead> {
             })
         }
     }
-
-    /// Creates a "fake" capture handle for the given link type.  Takes an additional
-    /// precision argument specifying the time stamp precision desired.
-    pub fn dead_with_precision(linktype: Linktype, precision: Precision) -> Result<Capture<Dead>, Error> {
-        unsafe {
-            let handle = raw::pcap_open_dead_with_tstamp_precision(linktype.0, 65535, match precision {
-                Precision::Micro => 0,
-                Precision::Nano => 1,
-            });
-
-            if handle.is_null() {
-                return Err(Error::InsufficientMemory);
-            }
-
-            Ok(Capture {
-                handle: Unique::new(handle),
-                _marker: PhantomData
-            })
-        }
-    }
 }
 
 #[cfg(not(windows))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ pub enum Error {
     InvalidLinktype,
     TimeoutExpired,
     NoMorePackets,
+    InsufficientMemory,
 }
 
 impl Error {
@@ -108,6 +109,9 @@ impl fmt::Display for Error {
             NoMorePackets => {
                write!(f, "no more packets to read from the file")
             },
+            InsufficientMemory => {
+                write!(f, "insufficient memory")
+            },
         }
     }
 }
@@ -121,6 +125,7 @@ impl std::error::Error for Error {
             InvalidLinktype => "invalid or unknown linktype",
             TimeoutExpired => "pcap was reading from a live capture and the timeout expired",
             NoMorePackets => "pcap was reading from a file and there were no more packets to read",
+            InsufficientMemory => "insufficient memory",
         }
     }
 
@@ -286,11 +291,16 @@ pub enum Active {}
 /// Phantom type representing an offline capture handle, from a pcap dump file.
 /// Implements `Activated` because it behaves nearly the same as a live handle.
 pub enum Offline {}
+/// Phantom type representing a dead capture handle.  This can be use to create
+/// new save files that are not generated from an active capture.
+/// Implements `Activated` because it behaves nearly the same as a live handle.
+pub enum Dead {}
 
 pub unsafe trait Activated: State {}
 
 unsafe impl Activated for Active {}
 unsafe impl Activated for Offline {}
+unsafe impl Activated for Dead {}
 
 /// `Capture`s can be in different states at different times, and in these states they
 /// may or may not have particular capabilities. This trait is implemented by phantom
@@ -301,6 +311,7 @@ pub unsafe trait State {}
 unsafe impl State for Inactive {}
 unsafe impl State for Active {}
 unsafe impl State for Offline {}
+unsafe impl State for Dead {}
 
 /// This is a pcap capture handle which is an abstraction over the `pcap_t` provided by pcap.
 /// There are many ways to instantiate and interact with a pcap handle, so phantom types are
@@ -317,6 +328,9 @@ unsafe impl State for Offline {}
 /// **`Capture<Offline>`** is created via `Capture::from_file()`. This allows you to read a
 /// pcap format dump file as if you were opening an interface -- very useful for testing or
 /// analysis.
+///
+/// **`Capture<Dead>`** is created via `Capture::dead()`. This allows you to create a pcap
+/// format dump file without needing an active capture.
 ///
 /// # Example:
 ///
@@ -682,6 +696,43 @@ impl Capture<Active> {
                     Ok(())
                 }
             }
+        }
+    }
+}
+
+impl Capture<Dead> {
+    /// Creates a "fake" capture handle for the given link type.
+    pub fn dead(linktype: Linktype) -> Result<Capture<Dead>, Error> {
+        unsafe {
+            let handle = raw::pcap_open_dead(linktype.0, 65535);
+            if handle.is_null() {
+                return Err(Error::InsufficientMemory);
+            }
+
+            Ok(Capture {
+                handle: Unique::new(handle),
+                _marker: PhantomData
+            })
+        }
+    }
+
+    /// Creates a "fake" capture handle for the given link type.  Takes an additional
+    /// precision argument specifying the time stamp precision desired.
+    pub fn dead_with_precision(linktype: Linktype, precision: Precision) -> Result<Capture<Dead>, Error> {
+        unsafe {
+            let handle = raw::pcap_open_dead_with_tstamp_precision(linktype.0, 65535, match precision {
+                Precision::Micro => 0,
+                Precision::Nano => 1,
+            });
+
+            if handle.is_null() {
+                return Err(Error::InsufficientMemory);
+            }
+
+            Ok(Capture {
+                handle: Unique::new(handle),
+                _marker: PhantomData
+            })
         }
     }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -693,11 +693,11 @@ extern "C" {
     // pub fn pcap_open_live(arg1: *const ::libc::c_char, arg2: ::libc::c_int,
     //                       arg3: ::libc::c_int, arg4: ::libc::c_int,
     //                       arg5: *mut ::libc::c_char) -> *mut pcap_t;
-    // pub fn pcap_open_dead(arg1: ::libc::c_int, arg2: ::libc::c_int)
-    //  -> *mut pcap_t;
-    // pub fn pcap_open_dead_with_tstamp_precision(arg1: ::libc::c_int,
-    //                                             arg2: ::libc::c_int,
-    //                                             arg3: u_int) -> *mut pcap_t;
+    pub fn pcap_open_dead(arg1: ::libc::c_int, arg2: ::libc::c_int)
+      -> *mut pcap_t;
+    pub fn pcap_open_dead_with_tstamp_precision(arg1: ::libc::c_int,
+                                                 arg2: ::libc::c_int,
+                                                 arg3: u_int) -> *mut pcap_t;
     pub fn pcap_open_offline_with_tstamp_precision(arg1:
                                                        *const ::libc::c_char,
                                                    arg2: u_int,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 extern crate pcap;
 extern crate libc;
 
-use pcap::{Active, Activated, Offline, Capture, Packet, PacketHeader, Precision};
+use pcap::{Active, Activated, Offline, Capture, Packet, PacketHeader};
 use std::env;
 use std::fs;
 use std::path::Path;
@@ -94,65 +94,6 @@ fn capture_dead_savefile() {
 			let orig_packet = &packets[idx];
 			assert_eq!(orig_packet.header.ts.tv_sec, packet.header.ts.tv_sec);
 			assert_eq!(orig_packet.header.ts.tv_usec, packet.header.ts.tv_usec);
-			assert_eq!(orig_packet.header.caplen, packet.header.caplen);
-			assert_eq!(orig_packet.header.len, packet.header.len);
-			assert_eq!(orig_packet.data, packet.data);
-
-			idx += 1;
-		}
-	}
-
-	fs::remove_file(&tmp_file).unwrap();
-}
-#[test]
-fn capture_dead_with_precision_savefile() {
-	let p1_header = PacketHeader {
-		ts: libc::timeval {
-			tv_sec: 1460408319,
-			tv_usec: 1234000,
-		},
-		caplen: 1,
-		len: 1,
-	};
-	let p1_data = vec![1u8];
-
-	let p2_header = PacketHeader {
-		ts: libc::timeval {
-			tv_sec: 1460408320,
-			tv_usec: 4321000,
-		},
-		caplen: 1,
-		len: 1,
-	};
-	let p2_data = vec![2u8];
-
-	let mut packets = vec![];
-	packets.push(Packet { header: &p1_header, data: &p1_data });
-	packets.push(Packet { header: &p2_header, data: &p2_data });
-
-	let mut tmp_file = env::temp_dir();
-	tmp_file.push("pcap_dead_prec_savefile_test.pcap");
-
-	{
-		// Scope for dead capture
-		let dead_cap = pcap::Capture::dead_with_precision(
-			pcap::Linktype(1),
-			Precision::Nano,
-		).unwrap();
-		let mut dead_save = dead_cap.savefile(&tmp_file).unwrap();
-		for packet in &packets {
-			dead_save.write(&packet);
-		}
-	}
-
-	{
-		// Scope for offline capture
-		let mut offline_cap = pcap::Capture::from_file(&tmp_file).unwrap();
-		let mut idx = 0;
-		while let Ok(packet) = offline_cap.next() {
-			let orig_packet = &packets[idx];
-			assert_eq!(orig_packet.header.ts.tv_sec, packet.header.ts.tv_sec);
-			assert_eq!(orig_packet.header.ts.tv_usec/1000, packet.header.ts.tv_usec);
 			assert_eq!(orig_packet.header.caplen, packet.header.caplen);
 			assert_eq!(orig_packet.header.len, packet.header.len);
 			assert_eq!(orig_packet.data, packet.data);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,9 @@
 extern crate pcap;
+extern crate libc;
 
-use pcap::{Active, Activated, Offline, Capture};
+use pcap::{Active, Activated, Offline, Capture, Packet, PacketHeader, Precision};
+use std::env;
+use std::fs;
 use std::path::Path;
 
 #[test]
@@ -43,4 +46,120 @@ fn unify_activated() {
 	fn also_maybe(a: &mut Capture<Activated>) {
 		a.filter("whatever filter string, this won't be run anyway").unwrap();
 	}
+}
+
+#[test]
+fn capture_dead_savefile() {
+	let p1_header = PacketHeader {
+		ts: libc::timeval {
+			tv_sec: 1460408319,
+			tv_usec: 1234,
+		},
+		caplen: 1,
+		len: 1,
+	};
+	let p1_data = vec![1u8];
+
+	let p2_header = PacketHeader {
+		ts: libc::timeval {
+			tv_sec: 1460408320,
+			tv_usec: 4321,
+		},
+		caplen: 1,
+		len: 1,
+	};
+	let p2_data = vec![2u8];
+
+	let mut packets = vec![];
+	packets.push(Packet { header: &p1_header, data: &p1_data });
+	packets.push(Packet { header: &p2_header, data: &p2_data });
+
+	let mut tmp_file = env::temp_dir();
+	tmp_file.push("pcap_dead_savefile_test.pcap");
+
+	{
+		// Scope for dead capture
+		let dead_cap = pcap::Capture::dead(pcap::Linktype(1)).unwrap();
+		let mut dead_save = dead_cap.savefile(&tmp_file).unwrap();
+		for packet in &packets {
+			dead_save.write(&packet);
+		}
+	}
+
+	{
+		// Scope for offline capture
+		let mut offline_cap = pcap::Capture::from_file(&tmp_file).unwrap();
+		let mut idx = 0;
+		while let Ok(packet) = offline_cap.next() {
+			let orig_packet = &packets[idx];
+			assert_eq!(orig_packet.header.ts.tv_sec, packet.header.ts.tv_sec);
+			assert_eq!(orig_packet.header.ts.tv_usec, packet.header.ts.tv_usec);
+			assert_eq!(orig_packet.header.caplen, packet.header.caplen);
+			assert_eq!(orig_packet.header.len, packet.header.len);
+			assert_eq!(orig_packet.data, packet.data);
+
+			idx += 1;
+		}
+	}
+
+	fs::remove_file(&tmp_file).unwrap();
+}
+#[test]
+fn capture_dead_with_precision_savefile() {
+	let p1_header = PacketHeader {
+		ts: libc::timeval {
+			tv_sec: 1460408319,
+			tv_usec: 1234000,
+		},
+		caplen: 1,
+		len: 1,
+	};
+	let p1_data = vec![1u8];
+
+	let p2_header = PacketHeader {
+		ts: libc::timeval {
+			tv_sec: 1460408320,
+			tv_usec: 4321000,
+		},
+		caplen: 1,
+		len: 1,
+	};
+	let p2_data = vec![2u8];
+
+	let mut packets = vec![];
+	packets.push(Packet { header: &p1_header, data: &p1_data });
+	packets.push(Packet { header: &p2_header, data: &p2_data });
+
+	let mut tmp_file = env::temp_dir();
+	tmp_file.push("pcap_dead_prec_savefile_test.pcap");
+
+	{
+		// Scope for dead capture
+		let dead_cap = pcap::Capture::dead_with_precision(
+			pcap::Linktype(1),
+			Precision::Nano,
+		).unwrap();
+		let mut dead_save = dead_cap.savefile(&tmp_file).unwrap();
+		for packet in &packets {
+			dead_save.write(&packet);
+		}
+	}
+
+	{
+		// Scope for offline capture
+		let mut offline_cap = pcap::Capture::from_file(&tmp_file).unwrap();
+		let mut idx = 0;
+		while let Ok(packet) = offline_cap.next() {
+			let orig_packet = &packets[idx];
+			assert_eq!(orig_packet.header.ts.tv_sec, packet.header.ts.tv_sec);
+			assert_eq!(orig_packet.header.ts.tv_usec/1000, packet.header.ts.tv_usec);
+			assert_eq!(orig_packet.header.caplen, packet.header.caplen);
+			assert_eq!(orig_packet.header.len, packet.header.len);
+			assert_eq!(orig_packet.data, packet.data);
+
+			idx += 1;
+		}
+	}
+
+	fs::remove_file(&tmp_file).unwrap();
 }


### PR DESCRIPTION
This will allow creating pcap save files without needing to capture from an actual interface.

It was a pretty straightforward implementation but there were two things I wasn't sure how you wanted to handle.

I named the function to create them "dead" because I couldn't think of anything better since it's not really "from_" anything.
I wanted to have a sane default for the snaplen parameter but I didn't want to end up with a bunch of functions to create the struct, so I defaulted it to 65535.  I figured if anyone wants to change it they can use snaplen().

Let me know if you want me to change any of this! I think this will work for me as I was able to successfully create a new capture file with the code.  I'm not sure I'll get my "write directly to a Vec<u8>" because of how pcap writes the packets but I can always throw it in a temp file.