### PR TITLE
Allow creation of Savefiles in-memory only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 libc = "0.2.7"
+rand = "0.3.14"
 
 [lib]
 name = "pcap"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ extern crate libc;
 extern crate rand;
 
 use unique::Unique;
+#[cfg(not(any(windows, target_os="macos")))]
 use rand::Rng;
 use std::marker::PhantomData;
 use std::ptr;
@@ -594,7 +595,7 @@ impl<T: Activated + ?Sized> Capture<T> {
     /// Create a `Savememory` context for recording captures packets using this `Capture`'s
     /// configurations.  This is similar to `savefile()` except it uses memory instead of a file.
     /// This is not available on Windows or OS X.
-    #[cfg(not(any(windows, macos)))]
+    #[cfg(not(any(windows, target_os="macos")))]
     pub fn savememory(&self) -> Result<Savememory, Error> {
         Savememory::new(*self.handle)
     }
@@ -787,14 +788,14 @@ impl Drop for Savefile {
 
 /// Abstraction for writing pcap savefiles in memory.  The `dump()` function can be used
 /// to retrieve a clone of the data currently in the savefile.
-#[cfg(not(any(windows, macos)))]
+#[cfg(not(any(windows, target_os="macos")))]
 pub struct Savememory {
     handle: Unique<raw::pcap_dumper_t>,
     shm_fd: libc::c_int,
     shm_file: *mut libc::FILE,
 }
 
-#[cfg(not(any(windows, macos)))]
+#[cfg(not(any(windows, target_os="macos")))]
 impl Savememory {
     /// Creates a new in-memory pcap file for the given pcap handle.
     fn new(pcap_handle: *mut raw::pcap_t) -> Result<Savememory, Error> {
@@ -887,7 +888,7 @@ impl Savememory {
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os="macos")))]
 impl Drop for Savememory {
     fn drop(&mut self) {
         unsafe {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -772,8 +772,8 @@ extern "C" {
     pub fn pcap_fileno(arg1: *mut pcap_t) -> ::libc::c_int;
     pub fn pcap_dump_open(arg1: *mut pcap_t, arg2: *const ::libc::c_char)
      -> *mut pcap_dumper_t;
-    // pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE)
-    //  -> *mut pcap_dumper_t;
+    pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE)
+     -> *mut pcap_dumper_t;
     // pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut FILE;
     // pub fn pcap_dump_ftell(arg1: *mut pcap_dumper_t) -> ::libc::c_long;
     // pub fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> ::libc::c_int;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -50,7 +50,7 @@ fn unify_activated() {
 }
 
 #[test]
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os="macos")))]
 fn capture_dead_savememory() {
 	let p1_header = PacketHeader {
 		ts: libc::timeval {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,6 +3,7 @@ extern crate libc;
 
 use pcap::{Active, Activated, Offline, Capture, Packet, PacketHeader};
 use std::env;
+use std::io::Write;
 use std::fs;
 use std::path::Path;
 
@@ -46,6 +47,68 @@ fn unify_activated() {
 	fn also_maybe(a: &mut Capture<Activated>) {
 		a.filter("whatever filter string, this won't be run anyway").unwrap();
 	}
+}
+
+#[test]
+#[cfg(not(windows))]
+fn capture_dead_savememory() {
+	let p1_header = PacketHeader {
+		ts: libc::timeval {
+			tv_sec: 1460408319,
+			tv_usec: 1234,
+		},
+		caplen: 1,
+		len: 1,
+	};
+	let p1_data = vec![1u8];
+
+	let p2_header = PacketHeader {
+		ts: libc::timeval {
+			tv_sec: 1460408320,
+			tv_usec: 4321,
+		},
+		caplen: 1,
+		len: 1,
+	};
+	let p2_data = vec![2u8];
+
+	let mut packets = vec![];
+	packets.push(Packet { header: &p1_header, data: &p1_data });
+	packets.push(Packet { header: &p2_header, data: &p2_data });
+
+	let mut tmp_file = env::temp_dir();
+	tmp_file.push("pcap_dead_savememory_test.pcap");
+
+	{
+		// Scope for dead capture
+		let dead_cap = pcap::Capture::dead(pcap::Linktype(1)).unwrap();
+		let mut dead_save = dead_cap.savememory().unwrap();
+		for packet in &packets {
+			dead_save.write(&packet);
+		}
+		let contents = dead_save.dump().unwrap();
+
+		let mut file = fs::File::create(&tmp_file).unwrap();
+		file.write_all(&contents).unwrap();
+	}
+
+	{
+		// Scope for offline capture
+		let mut offline_cap = pcap::Capture::from_file(&tmp_file).unwrap();
+		let mut idx = 0;
+		while let Ok(packet) = offline_cap.next() {
+			let orig_packet = &packets[idx];
+			assert_eq!(orig_packet.header.ts.tv_sec, packet.header.ts.tv_sec);
+			assert_eq!(orig_packet.header.ts.tv_usec, packet.header.ts.tv_usec);
+			assert_eq!(orig_packet.header.caplen, packet.header.caplen);
+			assert_eq!(orig_packet.header.len, packet.header.len);
+			assert_eq!(orig_packet.data, packet.data);
+
+			idx += 1;
+		}
+	}
+
+	fs::remove_file(&tmp_file).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This adds a "savememory()" function to Capture that uses shared memory to write the pcap file directly to memory instead of requiring a file on the filesystem first.

At this point it doesn't support Windows and OS X.  I tried to get it running on OS X but apparently it really doesn't like fseek (or much of anything) on shared memory so I left that as an exercise to someone who's better versed in Windows and/or OS X.

I screwed up my rebase so there are some double commits and a merge, sorry. =/