### PR TITLE
Fixing ARM compilation errors for new code. See ebfull/pcap@02e45121b.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,9 +378,9 @@ impl Capture<Offline> {
             let handle = raw::pcap_open_offline_with_tstamp_precision(name.as_ptr(), match precision {
                 Precision::Micro => 0,
                 Precision::Nano => 1,
-            }, errbuf.as_mut_ptr());
+            }, errbuf.as_mut_ptr() as *mut _);
             if handle.is_null() {
-                return Error::new(errbuf.as_ptr());
+                return Error::new(errbuf.as_ptr() as *const _);
             }
 
             Ok(Capture {


### PR DESCRIPTION
This fixes a problem with some architecture-dependent types. The errors can be produced by compiling on an ARM processor (e.g. Raspberry Pi).

There was an earlier [commit](https://github.com/ebfull/pcap/commit/02e45121b3f7f48c0d6a7de2cb533f4395c9928a) that fixed this issue, but a later change introduced a regression.