### PR TITLE
Support "immediate mode"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,6 +557,32 @@ impl Capture<Inactive> {
         self
     }
 
+    /// Set immediate mode on or off for a not-yet-activated capture handle.
+    /// Separate implementations are required for Windows, Mac, and Linux.
+    /// Windows and Mac do not support pcap_set_immediate.
+    //
+    // Linux must be set on an Inactive Capture. Mac requires an Active Capture.
+    // Currently unsure if Windows cares (It definitely works with an Active Capture).
+    //
+    // Question 1:
+    //   Context: It's my understanding that determining the installed version of libpcap
+    //            is problematic. Thus, checking for feature support is difficult.
+    //   * Should we change this guard to Not Win + Not Mac and rely on Issues to find
+    //     find out where this fails?
+    //   * Or, should we whitelist OS's as they're needed? (I'm leaning toward the former)
+    //
+    // Question 2:
+    //   * pcap_set_immediate_mode returns PCAP_ERROR_ACTIVATED if called on an
+    //     activated capture handle. Since this is defined on Capture<Inactive>,
+    //     we can safely ignore this right?
+    #[cfg(target_os = "linux")]
+    pub fn immediate_mode(self, to: bool) -> Capture<Inactive> {
+        unsafe {
+            raw::pcap_set_immediate_mode(*self.handle, if to {1} else {0});
+            self
+        }
+    }
+
     /// Set the time stamp precision returned in captures.
     #[cfg(not(windows))]
     pub fn precision(self, precision: Precision) -> Capture<Inactive> {
@@ -749,21 +775,9 @@ impl Capture<Active> {
     /// Set immediate mode on or off for a not-yet-activated capture handle.
     /// Separate implementations are required for Windows, Mac, and Linux.
     /// Windows and Mac do not support pcap_set_immediate.
-    // TODO: This may need to be on Capture<Inactive> for Linux. Not ideal.
-    //#[cfg(linux)]
-    //pub fn immediate_mode(self, to: bool) -> Capture<Inactive> {
-    //    unsafe {
-    //        raw::pcap_set_immediate_mode(*self.handle, if to {1} else {0});
-    //        self
-    //    }
-    //}
-
-    /// Set immediate mode on or off for a not-yet-activated capture handle.
-    /// Separate implementations are required for Windows, Mac, and Linux.
-    /// Windows and Mac do not support pcap_set_immediate.
-    // Idea: If Linux is set on Inactive Capture,
+    // Idea: Since Linux is set on Inactive Capture, should we
     //       have the OS X method set a flag that is checked for when the
-    //       capture is activated which actually sets the immediate mode
+    //       capture is activated which actually enables immediate mode
     //       in order to keep the API consistent.
     // Question 1: Do BSD's use BIOCIMMEDIATE or pcap_set_immediate_mode?
     //             This guard should be updated if the former.

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -93,7 +93,7 @@ extern "C" {
     pub fn pcap_set_timeout(arg1: *mut pcap_t, arg2: c_int) -> c_int;
     #[cfg(not(windows))]
     pub fn pcap_set_tstamp_type(arg1: *mut pcap_t, arg2: c_int) -> c_int;
-    // pub fn pcap_set_immediate_mode(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+    pub fn pcap_set_immediate_mode(arg1: *mut pcap_t, arg2: c_int) -> c_int;
     pub fn pcap_set_buffer_size(arg1: *mut pcap_t, arg2: c_int) -> c_int;
     #[cfg(not(windows))]
     pub fn pcap_set_tstamp_precision(arg1: *mut pcap_t, arg2: c_int) -> c_int;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -175,7 +175,10 @@ extern "C" {
 
 #[cfg(windows)]
 #[link(name = "wpcap")]
-extern "C" {}
+extern "C" {
+    pub fn pcap_setmintocopy(arg1: *mut pcap_t, arg2: c_int)
+     -> c_int;
+}
 
 #[cfg(not(windows))]
 #[link(name = "pcap")]


### PR DESCRIPTION
This PR brings support for libpcap's "immediate mode" on Windows (setmintocopy), Mac(ioctl - BIOCIMMEDIATE), and Linux(set_immediate_mode).

It is very much a **WIP** right now. This is my first time playing with Rust or libpcap, so there are several things I'd like to clarify before calling this done. Also, I'm not familiar with proper Rust documentation yet, but I'll get that corrected ASAP. I just wanted to get this out there so we could get the discussion going.

I'll update this PR from feedback, and rebase it when it's done so you don't have a bunch of useless commits.

The questions I have are documented in the diff for simplicity (I hope). Please let me know if they'd be better in a comment.

Largely, I'm just hoping to clarify preferences. The biggest issue is that libpcap on OS X requires an activated capture to enable immediate mode, and libpcap on Linux requires an inactive capture. This causes an inconsistent API `.immediate_mode(true).open().unwrap()` vs `.open().unwrap().immediate_mode(true)`. 

It seems to me that `immediate_mode()` should be defined on `Capture<Inactive>` for every OS. For those that require an active capture, `immediate_mode() -> Capture<Inactive>` should set a flag that is checked for when the capture is `open()`'d. `open()` would then take the necessary steps to enable "immediate mode". This would keep the API consistent cross-platform. 

Is there a better way? If not, what is the best way to implement this?

Thanks
## Test program

``` rust
extern crate pcap;

fn main() {

    // immediate_mode(false): print packets after timeout or buffer fills
    // immediate_mode(true): print packets as soon as they arrive
    let mut cap = pcap::Capture::from_device(YOURDEVICENAMEHERE).unwrap()
      .timeout(10000) // When "immediate mode" is enabled, this tells you that no packets were received and keeps it from blocking on some systems
      // .immediate_mode(true).open().unwrap(); // Linux only: uncomment this line and comment the next.
      open().unwrap().immediate_mode(true); 

   // Wake-on-lan packets are an easy way to test immediate mode because they're
   // easy to trigger and fairly rare.
   // If you have "wakeonlan" installed, simply:
   // `wakeonlan $RANDOMMAC`
   // With immediate mode enabled, running that command multiple times should print packets 
   // right away.
   // Without it, it should take at least 10000ms (10s) for the first packet to print (Unless
   // you run `wakeonlan` in a loop and manage to fill up the buffer before the 10s timeout,
   // but even that will show a delay compared to immediate mode.
    cap.filter("ether proto 0x0842 or udp port 7 or udp port 9").unwrap();

    println!("{:?}", cap.next());
    println!("{:?}", cap.next());
    println!("{:?}", cap.next());
    println!("{:?}", cap.next());
    println!("{:?}", cap.next());
}
```

Closes #45 
