### PR TITLE
allow appending to save files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 libc = "0.2.7"
 
+[features]
+# This feature enables access to the function Capture::savefile_append.
+# This is disabled by default, because it depends on a relatively recent
+# version of libpcap (1.7.2).
+pcap-savefile-append = []
+
 [lib]
 name = "pcap"
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ libpcap should be installed on Mac OS X by default.
 
 **Note:** A timeout of zero may cause ```pcap::Capture::next``` to hang and never return (because it waits for the timeout to expire before returning). This can be fixed by using a non-zero timeout (as the libpcap manual recommends) and calling ```pcap::Capture::next``` in a loop.
 
+## Optional Features
+
+To get access to the `Capture::savefile_append` function (which allows appending
+to an existing pcap file) you have to depend on the `pcap-savefile-append`
+feature flag. It requires at least libpcap version 1.7.2.
+
+    [dependencies]
+    pcap = { version = "*", features = "pcap-savefile-append" }
+
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ impl Linktype {
 }
 
 /// Represents a packet returned from pcap.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Packet<'a> {
     pub header: &'a PacketHeader,
     pub data: &'a [u8]
@@ -575,6 +575,27 @@ impl<T: Activated + ?Sized> Capture<T> {
         let name = CString::new(path.as_ref().to_str().unwrap()).unwrap();
         unsafe {
             let handle = raw::pcap_dump_open(*self.handle, name.as_ptr());
+
+            if handle.is_null() {
+                Error::new(raw::pcap_geterr(*self.handle))
+            } else {
+                Ok(Savefile {
+                    handle: Unique::new(handle)
+                })
+            }
+        }
+    }
+
+    /// Reopen a `Savefile` context for recording captured packets using this `Capture`'s
+    /// configurations. This is similar to `savefile()` but does not create the file if it
+    /// does  not exist and, if it does already exist, and is a pcap file with the same
+    /// byte order as the host opening the file, and has the same time stamp precision,
+    /// link-layer header type,  and  snapshot length as p, it will write new packets
+    /// at the end of the file.
+    pub fn savefile_append<P: AsRef<Path>>(&self, path: P) -> Result<Savefile, Error> {
+        let name = CString::new(path.as_ref().to_str().unwrap()).unwrap();
+        unsafe {
+            let handle = raw::pcap_dump_open_append(*self.handle, name.as_ptr());
 
             if handle.is_null() {
                 Error::new(raw::pcap_geterr(*self.handle))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,6 +592,7 @@ impl<T: Activated + ?Sized> Capture<T> {
     /// byte order as the host opening the file, and has the same time stamp precision,
     /// link-layer header type,  and  snapshot length as p, it will write new packets
     /// at the end of the file.
+    #[cfg(feature = "pcap-savefile-append")]
     pub fn savefile_append<P: AsRef<Path>>(&self, path: P) -> Result<Savefile, Error> {
         let name = CString::new(path.as_ref().to_str().unwrap()).unwrap();
         unsafe {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -776,6 +776,8 @@ extern "C" {
      -> *mut pcap_dumper_t;
     // pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE)
     //  -> *mut pcap_dumper_t;
+    pub fn pcap_dump_open_append(arg1: *mut pcap_t, arg2: *const ::libc::c_char)
+     -> *mut pcap_dumper_t;
     // pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut FILE;
     // pub fn pcap_dump_ftell(arg1: *mut pcap_dumper_t) -> ::libc::c_long;
     // pub fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> ::libc::c_int;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -776,6 +776,7 @@ extern "C" {
      -> *mut pcap_dumper_t;
     // pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE)
     //  -> *mut pcap_dumper_t;
+    #[cfg(feature = "pcap-savefile-append")]
     pub fn pcap_dump_open_append(arg1: *mut pcap_t, arg2: *const ::libc::c_char)
      -> *mut pcap_dumper_t;
     // pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut FILE;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -104,3 +104,97 @@ fn capture_dead_savefile() {
 
 	fs::remove_file(&tmp_file).unwrap();
 }
+
+#[test]
+fn capture_dead_savefile_append() {
+	let p1_header = PacketHeader {
+		ts: libc::timeval {
+			tv_sec: 1460408319,
+			tv_usec: 1234,
+		},
+		caplen: 1,
+		len: 1,
+	};
+	let p1_data = vec![1u8];
+
+	let p2_header = PacketHeader {
+		ts: libc::timeval {
+			tv_sec: 1460408320,
+			tv_usec: 4321,
+		},
+		caplen: 1,
+		len: 1,
+	};
+	let p2_data = vec![2u8];
+
+	let p3_header = PacketHeader {
+		ts: libc::timeval {
+			tv_sec: 1460408321,
+			tv_usec: 2345,
+		},
+		caplen: 1,
+		len: 1,
+	};
+	let p3_data = vec![3u8];
+
+	let p4_header = PacketHeader {
+		ts: libc::timeval {
+			tv_sec: 1460408322,
+			tv_usec: 5432,
+		},
+		caplen: 1,
+		len: 1,
+	};
+	let p4_data = vec![4u8];
+
+	let mut packets1 = vec![];
+	packets1.push(Packet { header: &p1_header, data: &p1_data });
+	packets1.push(Packet { header: &p2_header, data: &p2_data });
+
+	let mut packets2 = vec![];
+	packets2.push(Packet { header: &p3_header, data: &p3_data });
+	packets2.push(Packet { header: &p4_header, data: &p4_data });
+
+	let mut packets = vec![];
+	packets.extend(packets1.iter().cloned());
+	packets.extend(packets2.iter().cloned());
+
+	let mut tmp_file = env::temp_dir();
+	tmp_file.push("pcap_dead_savefile_append_test.pcap");
+
+	{
+		// Scope for dead capture
+		let dead_cap = pcap::Capture::dead(pcap::Linktype(1)).unwrap();
+		let mut dead_save = dead_cap.savefile(&tmp_file).unwrap();
+		for packet in &packets1 {
+			dead_save.write(&packet);
+		}
+	}
+
+	{
+		// Scope for appending to dead capture
+		let dead_cap = pcap::Capture::dead(pcap::Linktype(1)).unwrap();
+		let mut dead_save = dead_cap.savefile_append(&tmp_file).unwrap();
+		for packet in &packets2 {
+			dead_save.write(&packet);
+		}
+	}
+
+	{
+		// Scope for offline capture
+		let mut offline_cap = pcap::Capture::from_file(&tmp_file).unwrap();
+		let mut idx = 0;
+		while let Ok(packet) = offline_cap.next() {
+			let orig_packet = &packets[idx];
+			assert_eq!(orig_packet.header.ts.tv_sec, packet.header.ts.tv_sec);
+			assert_eq!(orig_packet.header.ts.tv_usec, packet.header.ts.tv_usec);
+			assert_eq!(orig_packet.header.caplen, packet.header.caplen);
+			assert_eq!(orig_packet.header.len, packet.header.len);
+			assert_eq!(orig_packet.data, packet.data);
+
+			idx += 1;
+		}
+	}
+
+	fs::remove_file(&tmp_file).unwrap();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -106,6 +106,7 @@ fn capture_dead_savefile() {
 }
 
 #[test]
+#[cfg(feature = "pcap-savefile-append")]
 fn capture_dead_savefile_append() {
 	let p1_header = PacketHeader {
 		ts: libc::timeval {


### PR DESCRIPTION
This adds a parameter to Capture::savefile() that allows appending to the pcap file instead of creating a new one.

If you'd prefer another function over a boolean parameter like in the underlying pcap API, I can do that too. I'm a bit undecided which solution is better.