### PR TITLE
Support specifying libpcap location explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://ebfull.github.io/pcap/"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-libc = "0.2.7"
+libc = "0.2"
 
 [features]
 # This feature enables access to the function Capture::savefile_append.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/ebfull/pcap"
 repository = "https://github.com/ebfull/pcap"
 documentation = "https://ebfull.github.io/pcap/"
 license = "MIT OR Apache-2.0"
+build = "build.rs"
 
 [dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ libpcap should be installed on Mac OS X by default.
 
 **Note:** A timeout of zero may cause ```pcap::Capture::next``` to hang and never return (because it waits for the timeout to expire before returning). This can be fixed by using a non-zero timeout (as the libpcap manual recommends) and calling ```pcap::Capture::next``` in a loop.
 
+## Specifying library folder
+
+If `PCAP_LIBDIR` environment variable is set when building the crate, it will be added to the linker search path - this allows linking against a specific `libpcap`.
+
 ## Optional Features
 
 To get access to the `Capture::savefile_append` function (which allows appending

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+use std::env;
+
+fn main() {
+    if let Ok(libdir) = env::var("PCAP_LIBDIR") {
+        println!("cargo:rustc-link-search={}", libdir);
+    }
+}


### PR DESCRIPTION
* If `PCAP_LIBDIR` environment variable is set, add that to linker search path; this allows linking against a user-specified libpcap and not just the one at the default system-wide location.
* Minor: also relax libc requirement to just major/minor; this is more common than pinning the micro version and useful e.g. in workspaces.