### PR TITLE
Implement PartialEq and Eq for PacketHeader and Packet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ impl Linktype {
 }
 
 /// Represents a packet returned from pcap.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Packet<'a> {
     pub header: &'a PacketHeader,
     pub data: &'a [u8]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -595,6 +595,15 @@ impl ::std::fmt::Debug for PacketHeader {
     }
 }
 
+impl PartialEq for PacketHeader {
+    fn eq(&self, rhs: &PacketHeader) -> bool {
+        self.ts.tv_sec == rhs.ts.tv_sec && self.ts.tv_usec == rhs.ts.tv_usec &&
+            self.caplen == rhs.caplen && self.len == rhs.len
+    }
+}
+
+impl Eq for PacketHeader {}
+
 #[test]
 fn packet_hdr_eq() {
     use std::mem::size_of;


### PR DESCRIPTION
(`libc::timeval` doesn't derive `PartialEq` so it has to be done manually)