### PR TITLE
Add Capture::close() and Savefile::close() methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,6 +759,11 @@ impl AsRawFd for Capture<Active> {
     }
 }
 
+impl<T: State + ?Sized> Capture<T> {
+    /// Closes the capture handle.
+    pub fn close(self) {}
+}
+
 impl<T: State + ?Sized> Drop for Capture<T> {
     fn drop(&mut self) {
         unsafe {
@@ -784,6 +789,9 @@ impl Savefile {
             raw::pcap_dump(*self.handle as *mut u8, transmute::<_, &raw::Struct_pcap_pkthdr>(packet.header), packet.data.as_ptr());
         }
     }
+
+    /// Closes the savefile.
+    pub fn close(self) {}
 }
 
 impl Drop for Savefile {


### PR DESCRIPTION
This is a minor convenience but quite useful in some cases, so as not to introduce artificial scope blocks or do an explicit `drop()` just to close the handle.