### PR TITLE
Implement from_raw_fd(), from_raw_fd_with_precision(), savefile_raw_fd()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ build = "build.rs"
 [dependencies]
 libc = "0.2"
 
+[dev-dependencies]
+tempdir = "0.3"
+
 [features]
 # This feature enables access to the function Capture::savefile_append.
 # This is disabled by default, because it depends on a relatively recent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,13 @@ tempdir = "0.3"
 # version of libpcap (1.7.2).
 pcap-savefile-append = []
 
+# This feature enables access to the function Capture::from_raw_fd_with_precision.
+# This is disabled by default, because it requires libpcap >= 1.5.0.
+pcap-fopen-offline-precision = []
+
+# A shortcut to enable all features.
+full = ["pcap-savefile-append", "pcap-fopen-offline-precision"]
+
 [lib]
 name = "pcap"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ pub enum Error {
     TimeoutExpired,
     NoMorePackets,
     InsufficientMemory,
+    #[cfg(not(windows))]
+    InvalidRawFd,
 }
 
 impl Error {
@@ -112,6 +114,10 @@ impl fmt::Display for Error {
             InsufficientMemory => {
                 write!(f, "insufficient memory")
             },
+            #[cfg(not(windows))]
+            InvalidRawFd => {
+                write!(f, "invalid raw file descriptor")
+            },
         }
     }
 }
@@ -126,6 +132,8 @@ impl std::error::Error for Error {
             TimeoutExpired => "pcap was reading from a live capture and the timeout expired",
             NoMorePackets => "pcap was reading from a file and there were no more packets to read",
             InsufficientMemory => "insufficient memory",
+            #[cfg(not(windows))]
+            InvalidRawFd => "invalid raw file descriptor",
         }
     }
 
@@ -376,6 +384,60 @@ impl Capture<Offline> {
 
         unsafe {
             let handle = raw::pcap_open_offline_with_tstamp_precision(name.as_ptr(), match precision {
+                Precision::Micro => 0,
+                Precision::Nano => 1,
+            }, errbuf.as_mut_ptr() as *mut _);
+            if handle.is_null() {
+                return Error::new(errbuf.as_ptr() as *const _);
+            }
+
+            Ok(Capture {
+                handle: Unique::new(handle),
+                _marker: PhantomData
+            })
+        }
+    }
+
+    /// Opens an offline capture handle from a pcap dump file, given a file descriptor.
+    #[cfg(not(windows))]
+    pub fn from_raw_fd(fd: RawFd) -> Result<Capture<Offline>, Error> {
+        let mut errbuf = [0i8; PCAP_ERRBUF_SIZE];
+        const MODE: [u8; 2] = [b'r', 0];
+
+        unsafe {
+            // File handle will be closed by libpcap.
+            let file: *mut _ = libc::fdopen(fd, MODE.as_ptr() as *const _);
+            if file.is_null() {
+                return Err(Error::InvalidRawFd);
+            }
+
+            let handle = raw::pcap_fopen_offline(file, errbuf.as_mut_ptr() as *mut _);
+            if handle.is_null() {
+                return Error::new(errbuf.as_ptr() as *mut _);
+            }
+
+            Ok(Capture {
+                handle: Unique::new(handle),
+                _marker: PhantomData
+            })
+        }
+    }
+
+    /// Opens an offline capture handle from a pcap dump file, given a file descriptor.
+    /// Takes an additional precision argument specifying the time stamp precision desired.
+    #[cfg(all(not(windows), feature = "pcap-fopen-offline-precision"))]
+    pub fn from_raw_fd_with_precision(fd: RawFd, precision: Precision) -> Result<Capture<Offline>, Error> {
+        let mut errbuf = [0i8; PCAP_ERRBUF_SIZE];
+        const MODE: [u8; 2] = [b'r', 0];
+
+        unsafe {
+            // File handle will be closed by libpcap.
+            let file: *mut _ = libc::fdopen(fd, MODE.as_ptr() as *const _);
+            if file.is_null() {
+                return Err(Error::InvalidRawFd);
+            }
+
+            let handle = raw::pcap_fopen_offline_with_tstamp_precision(file, match precision {
                 Precision::Micro => 0,
                 Precision::Nano => 1,
             }, errbuf.as_mut_ptr() as *mut _);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ const PCAP_ERROR_NOT_ACTIVATED: i32 = -3;
 const PCAP_ERRBUF_SIZE: usize = 256;
 
 /// An error received from pcap
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     MalformedError(str::Utf8Error),
     InvalidString,

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -782,8 +782,8 @@ extern "C" {
     pub fn pcap_fileno(arg1: *mut pcap_t) -> ::libc::c_int;
     pub fn pcap_dump_open(arg1: *mut pcap_t, arg2: *const ::libc::c_char)
      -> *mut pcap_dumper_t;
-    // pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut ::libc::FILE)
-    //  -> *mut pcap_dumper_t;
+    pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut ::libc::FILE)
+     -> *mut pcap_dumper_t;
     #[cfg(feature = "pcap-savefile-append")]
     pub fn pcap_dump_open_append(arg1: *mut pcap_t, arg2: *const ::libc::c_char)
      -> *mut pcap_dumper_t;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -421,8 +421,6 @@ pub struct Struct_bpf_insn {
 impl ::std::default::Default for Struct_bpf_insn {
     fn default() -> Struct_bpf_insn { unsafe { ::std::mem::zeroed() } }
 }
-pub type FILE = Struct__IO_FILE;
-pub type __FILE = Struct__IO_FILE;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Struct_Unnamed14 {
@@ -716,12 +714,13 @@ extern "C" {
      -> *mut pcap_t;
     pub fn pcap_open_offline(arg1: *const ::libc::c_char,
                              arg2: *mut ::libc::c_char) -> *mut pcap_t;
-    // pub fn pcap_fopen_offline_with_tstamp_precision(arg1: *mut FILE,
-    //                                                 arg2: u_int,
-    //                                                 arg3: *mut ::libc::c_char)
-    //  -> *mut pcap_t;
-    // pub fn pcap_fopen_offline(arg1: *mut FILE, arg2: *mut ::libc::c_char)
-    //  -> *mut pcap_t;
+    #[cfg(feature = "pcap-fopen-offline-precision")]
+    pub fn pcap_fopen_offline_with_tstamp_precision(arg1: *mut ::libc::FILE,
+                                                    arg2: u_int,
+                                                    arg3: *mut ::libc::c_char)
+     -> *mut pcap_t;
+    pub fn pcap_fopen_offline(arg1: *mut ::libc::FILE, arg2: *mut ::libc::c_char)
+     -> *mut pcap_t;
     pub fn pcap_close(arg1: *mut pcap_t) -> ();
     // pub fn pcap_loop(arg1: *mut pcap_t, arg2: ::libc::c_int,
     //                  arg3: pcap_handler, arg4: *mut u_char) -> ::libc::c_int;
@@ -779,16 +778,16 @@ extern "C" {
     // pub fn pcap_is_swapped(arg1: *mut pcap_t) -> ::libc::c_int;
     // pub fn pcap_major_version(arg1: *mut pcap_t) -> ::libc::c_int;
     // pub fn pcap_minor_version(arg1: *mut pcap_t) -> ::libc::c_int;
-    // pub fn pcap_file(arg1: *mut pcap_t) -> *mut FILE;
+    // pub fn pcap_file(arg1: *mut pcap_t) -> *mut ::libc::FILE;
     pub fn pcap_fileno(arg1: *mut pcap_t) -> ::libc::c_int;
     pub fn pcap_dump_open(arg1: *mut pcap_t, arg2: *const ::libc::c_char)
      -> *mut pcap_dumper_t;
-    // pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE)
+    // pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut ::libc::FILE)
     //  -> *mut pcap_dumper_t;
     #[cfg(feature = "pcap-savefile-append")]
     pub fn pcap_dump_open_append(arg1: *mut pcap_t, arg2: *const ::libc::c_char)
      -> *mut pcap_dumper_t;
-    // pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut FILE;
+    // pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut ::libc::FILE;
     // pub fn pcap_dump_ftell(arg1: *mut pcap_dumper_t) -> ::libc::c_long;
     // pub fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> ::libc::c_int;
     pub fn pcap_dump_close(arg1: *mut pcap_dumper_t) -> ();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,176 +26,176 @@ fn capture_from_test_file(file_name: &str) -> Capture<Offline> {
 
 #[test]
 fn unify_activated() {
-	#![allow(dead_code)]
-	fn test1() -> Capture<Active> {
-		loop{}
-	}
+	  #![allow(dead_code)]
+	  fn test1() -> Capture<Active> {
+		    loop{}
+	  }
 
-	fn test2() -> Capture<Offline> {
-		loop{}
-	}
+	  fn test2() -> Capture<Offline> {
+		    loop{}
+	  }
 
-	fn maybe(a: bool) -> Capture<Activated> {
-		if a {
-			test1().into()
-		} else {
-			test2().into()
-		}
-	}
+	  fn maybe(a: bool) -> Capture<Activated> {
+		    if a {
+			      test1().into()
+		    } else {
+			      test2().into()
+		    }
+	  }
 
-	fn also_maybe(a: &mut Capture<Activated>) {
-		a.filter("whatever filter string, this won't be run anyway").unwrap();
-	}
+	  fn also_maybe(a: &mut Capture<Activated>) {
+		    a.filter("whatever filter string, this won't be run anyway").unwrap();
+	  }
 }
 
 #[test]
 fn capture_dead_savefile() {
-	let p1_header = PacketHeader {
-		ts: libc::timeval {
-			tv_sec: 1460408319,
-			tv_usec: 1234,
-		},
-		caplen: 1,
-		len: 1,
-	};
-	let p1_data = vec![1u8];
+	  let p1_header = PacketHeader {
+		    ts: libc::timeval {
+			      tv_sec: 1460408319,
+			      tv_usec: 1234,
+		    },
+		    caplen: 1,
+		    len: 1,
+	  };
+	  let p1_data = vec![1u8];
 
-	let p2_header = PacketHeader {
-		ts: libc::timeval {
-			tv_sec: 1460408320,
-			tv_usec: 4321,
-		},
-		caplen: 1,
-		len: 1,
-	};
-	let p2_data = vec![2u8];
+	  let p2_header = PacketHeader {
+		    ts: libc::timeval {
+			      tv_sec: 1460408320,
+			      tv_usec: 4321,
+		    },
+		    caplen: 1,
+		    len: 1,
+	  };
+	  let p2_data = vec![2u8];
 
-	let mut packets = vec![];
-	packets.push(Packet { header: &p1_header, data: &p1_data });
-	packets.push(Packet { header: &p2_header, data: &p2_data });
+	  let mut packets = vec![];
+	  packets.push(Packet { header: &p1_header, data: &p1_data });
+	  packets.push(Packet { header: &p2_header, data: &p2_data });
 
-	let mut tmp_file = env::temp_dir();
-	tmp_file.push("pcap_dead_savefile_test.pcap");
+	  let mut tmp_file = env::temp_dir();
+	  tmp_file.push("pcap_dead_savefile_test.pcap");
 
-	{
-		// Scope for dead capture
-		let dead_cap = pcap::Capture::dead(pcap::Linktype(1)).unwrap();
-		let mut dead_save = dead_cap.savefile(&tmp_file).unwrap();
-		for packet in &packets {
-			dead_save.write(&packet);
-		}
-	}
+	  {
+		    // Scope for dead capture
+		    let dead_cap = pcap::Capture::dead(pcap::Linktype(1)).unwrap();
+		    let mut dead_save = dead_cap.savefile(&tmp_file).unwrap();
+		    for packet in &packets {
+			      dead_save.write(&packet);
+		    }
+	  }
 
-	{
-		// Scope for offline capture
-		let mut offline_cap = pcap::Capture::from_file(&tmp_file).unwrap();
-		let mut idx = 0;
-		while let Ok(packet) = offline_cap.next() {
-			let orig_packet = &packets[idx];
-			assert_eq!(orig_packet.header.ts.tv_sec, packet.header.ts.tv_sec);
-			assert_eq!(orig_packet.header.ts.tv_usec, packet.header.ts.tv_usec);
-			assert_eq!(orig_packet.header.caplen, packet.header.caplen);
-			assert_eq!(orig_packet.header.len, packet.header.len);
-			assert_eq!(orig_packet.data, packet.data);
+	  {
+		    // Scope for offline capture
+		    let mut offline_cap = pcap::Capture::from_file(&tmp_file).unwrap();
+		    let mut idx = 0;
+		    while let Ok(packet) = offline_cap.next() {
+			      let orig_packet = &packets[idx];
+			      assert_eq!(orig_packet.header.ts.tv_sec, packet.header.ts.tv_sec);
+			      assert_eq!(orig_packet.header.ts.tv_usec, packet.header.ts.tv_usec);
+			      assert_eq!(orig_packet.header.caplen, packet.header.caplen);
+			      assert_eq!(orig_packet.header.len, packet.header.len);
+			      assert_eq!(orig_packet.data, packet.data);
 
-			idx += 1;
-		}
-	}
+			      idx += 1;
+		    }
+	  }
 
-	fs::remove_file(&tmp_file).unwrap();
+	  fs::remove_file(&tmp_file).unwrap();
 }
 
 #[test]
 #[cfg(feature = "pcap-savefile-append")]
 fn capture_dead_savefile_append() {
-	let p1_header = PacketHeader {
-		ts: libc::timeval {
-			tv_sec: 1460408319,
-			tv_usec: 1234,
-		},
-		caplen: 1,
-		len: 1,
-	};
-	let p1_data = vec![1u8];
+	  let p1_header = PacketHeader {
+		    ts: libc::timeval {
+			      tv_sec: 1460408319,
+			      tv_usec: 1234,
+		    },
+		    caplen: 1,
+		    len: 1,
+	  };
+	  let p1_data = vec![1u8];
 
-	let p2_header = PacketHeader {
-		ts: libc::timeval {
-			tv_sec: 1460408320,
-			tv_usec: 4321,
-		},
-		caplen: 1,
-		len: 1,
-	};
-	let p2_data = vec![2u8];
+	  let p2_header = PacketHeader {
+		    ts: libc::timeval {
+			      tv_sec: 1460408320,
+			      tv_usec: 4321,
+		    },
+		    caplen: 1,
+		    len: 1,
+	  };
+	  let p2_data = vec![2u8];
 
-	let p3_header = PacketHeader {
-		ts: libc::timeval {
-			tv_sec: 1460408321,
-			tv_usec: 2345,
-		},
-		caplen: 1,
-		len: 1,
-	};
-	let p3_data = vec![3u8];
+	  let p3_header = PacketHeader {
+		    ts: libc::timeval {
+			      tv_sec: 1460408321,
+			      tv_usec: 2345,
+		    },
+		    caplen: 1,
+		    len: 1,
+	  };
+	  let p3_data = vec![3u8];
 
-	let p4_header = PacketHeader {
-		ts: libc::timeval {
-			tv_sec: 1460408322,
-			tv_usec: 5432,
-		},
-		caplen: 1,
-		len: 1,
-	};
-	let p4_data = vec![4u8];
+	  let p4_header = PacketHeader {
+		    ts: libc::timeval {
+			      tv_sec: 1460408322,
+			      tv_usec: 5432,
+		    },
+		    caplen: 1,
+		    len: 1,
+	  };
+	  let p4_data = vec![4u8];
 
-	let mut packets1 = vec![];
-	packets1.push(Packet { header: &p1_header, data: &p1_data });
-	packets1.push(Packet { header: &p2_header, data: &p2_data });
+	  let mut packets1 = vec![];
+	  packets1.push(Packet { header: &p1_header, data: &p1_data });
+	  packets1.push(Packet { header: &p2_header, data: &p2_data });
 
-	let mut packets2 = vec![];
-	packets2.push(Packet { header: &p3_header, data: &p3_data });
-	packets2.push(Packet { header: &p4_header, data: &p4_data });
+	  let mut packets2 = vec![];
+	  packets2.push(Packet { header: &p3_header, data: &p3_data });
+	  packets2.push(Packet { header: &p4_header, data: &p4_data });
 
-	let mut packets = vec![];
-	packets.extend(packets1.iter().cloned());
-	packets.extend(packets2.iter().cloned());
+	  let mut packets = vec![];
+	  packets.extend(packets1.iter().cloned());
+	  packets.extend(packets2.iter().cloned());
 
-	let mut tmp_file = env::temp_dir();
-	tmp_file.push("pcap_dead_savefile_append_test.pcap");
+	  let mut tmp_file = env::temp_dir();
+	  tmp_file.push("pcap_dead_savefile_append_test.pcap");
 
-	{
-		// Scope for dead capture
-		let dead_cap = pcap::Capture::dead(pcap::Linktype(1)).unwrap();
-		let mut dead_save = dead_cap.savefile(&tmp_file).unwrap();
-		for packet in &packets1 {
-			dead_save.write(&packet);
-		}
-	}
+	  {
+		    // Scope for dead capture
+		    let dead_cap = pcap::Capture::dead(pcap::Linktype(1)).unwrap();
+		    let mut dead_save = dead_cap.savefile(&tmp_file).unwrap();
+		    for packet in &packets1 {
+			      dead_save.write(&packet);
+		    }
+	  }
 
-	{
-		// Scope for appending to dead capture
-		let dead_cap = pcap::Capture::dead(pcap::Linktype(1)).unwrap();
-		let mut dead_save = dead_cap.savefile_append(&tmp_file).unwrap();
-		for packet in &packets2 {
-			dead_save.write(&packet);
-		}
-	}
+	  {
+		    // Scope for appending to dead capture
+		    let dead_cap = pcap::Capture::dead(pcap::Linktype(1)).unwrap();
+		    let mut dead_save = dead_cap.savefile_append(&tmp_file).unwrap();
+		    for packet in &packets2 {
+			      dead_save.write(&packet);
+		    }
+	  }
 
-	{
-		// Scope for offline capture
-		let mut offline_cap = pcap::Capture::from_file(&tmp_file).unwrap();
-		let mut idx = 0;
-		while let Ok(packet) = offline_cap.next() {
-			let orig_packet = &packets[idx];
-			assert_eq!(orig_packet.header.ts.tv_sec, packet.header.ts.tv_sec);
-			assert_eq!(orig_packet.header.ts.tv_usec, packet.header.ts.tv_usec);
-			assert_eq!(orig_packet.header.caplen, packet.header.caplen);
-			assert_eq!(orig_packet.header.len, packet.header.len);
-			assert_eq!(orig_packet.data, packet.data);
+	  {
+		    // Scope for offline capture
+		    let mut offline_cap = pcap::Capture::from_file(&tmp_file).unwrap();
+		    let mut idx = 0;
+		    while let Ok(packet) = offline_cap.next() {
+			      let orig_packet = &packets[idx];
+			      assert_eq!(orig_packet.header.ts.tv_sec, packet.header.ts.tv_sec);
+			      assert_eq!(orig_packet.header.ts.tv_usec, packet.header.ts.tv_usec);
+			      assert_eq!(orig_packet.header.caplen, packet.header.caplen);
+			      assert_eq!(orig_packet.header.len, packet.header.len);
+			      assert_eq!(orig_packet.data, packet.data);
 
-			idx += 1;
-		}
-	}
+			      idx += 1;
+		    }
+	  }
 
-	fs::remove_file(&tmp_file).unwrap();
+	  fs::remove_file(&tmp_file).unwrap();
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,11 +1,12 @@
 extern crate pcap;
 extern crate libc;
+extern crate tempdir;
 
-use pcap::{Active, Activated, Offline, Capture, Packet, PacketHeader, Linktype};
-use std::env;
-use std::fs;
 use std::ops::Add;
 use std::path::Path;
+use tempdir::TempDir;
+
+use pcap::{Active, Activated, Offline, Capture, Packet, PacketHeader, Linktype};
 
 #[test]
 fn read_packet_with_full_data() {
@@ -23,7 +24,6 @@ fn capture_from_test_file(file_name: &str) -> Capture<Offline> {
     let path = Path::new("tests/data/").join(file_name);
     Capture::from_file(path).unwrap()
 }
-
 
 #[test]
 fn unify_activated() {
@@ -103,18 +103,16 @@ fn capture_dead_savefile() {
     packets.push(1460408319, 1234, 1, 1, &[1]);
     packets.push(1460408320, 4321, 1, 1, &[2]);
 
-	  let mut tmp_file = env::temp_dir();
-	  tmp_file.push("pcap_dead_savefile_test.pcap");
+    let dir = TempDir::new("pcap").unwrap();
+    let tmpfile = dir.path().join("test.pcap");
 
     let cap = Capture::dead(Linktype(1)).unwrap();
-    let mut save = cap.savefile(&tmp_file).unwrap();
+    let mut save = cap.savefile(&tmpfile).unwrap();
     packets.foreach(|p| save.write(p));
     drop(save);
 
-    let mut cap = Capture::from_file(&tmp_file).unwrap();
+    let mut cap = Capture::from_file(&tmpfile).unwrap();
     packets.verify(&mut cap);
-
-	  fs::remove_file(&tmp_file).unwrap();
 }
 
 #[test]
@@ -128,21 +126,19 @@ fn capture_dead_savefile_append() {
     packets2.push(1460408322, 5432, 1, 1, &[4]);
     let packets = &packets1 + &packets2;
 
-	  let mut tmp_file = env::temp_dir();
-	  tmp_file.push("pcap_dead_savefile_append_test.pcap");
+    let dir = TempDir::new("pcap").unwrap();
+    let tmpfile = dir.path().join("test.pcap");
 
     let cap = Capture::dead(Linktype(1)).unwrap();
-    let mut save = cap.savefile(&tmp_file).unwrap();
+    let mut save = cap.savefile(&tmpfile).unwrap();
     packets1.foreach(|p| save.write(p));
     drop(save);
 
     let cap = Capture::dead(Linktype(1)).unwrap();
-    let mut save = cap.savefile_append(&tmp_file).unwrap();
+    let mut save = cap.savefile_append(&tmpfile).unwrap();
     packets2.foreach(|p| save.write(p));
     drop(save);
 
-    let mut cap = Capture::from_file(&tmp_file).unwrap();
+    let mut cap = Capture::from_file(&tmpfile).unwrap();
     packets.verify(&mut cap);
-
-	  fs::remove_file(&tmp_file).unwrap();
 }


### PR DESCRIPTION
This adds support for both reading and writing to savefiles using raw descriptors on Unix platforms (+some tests refactoring and cleanup):

- `Capture<Offline>::from_raw_fd(fd: RawFd)`
- `Capture<Offline>::from_raw_fd_with_precision(fd: RawFd, precision: Precision)`
- `Capture<T>::savefile_raw_fd(fd: RawFd)`

The descriptors are opened via `fdopen()` and closed by libpcap. This piece of functionality is extremely helpful when reading/writing to e.g. gzipped pcaps -- the supplied tests emulate that use case.

A few minor open questions are: whether these new methods should be marked as `unsafe` and whether `FromRawFd` trait should be implemented.

An alternative would be to take in `*mut libc::FILE`, but that looks quite clunky in public API, and integer descriptor would be sufficient in most cases.

Note that there's large amounts of copy/paste in library code now, but I'd rather address that separately so as not to cram too much into a single PR.