### PR TITLE
Fix cstr_to_string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ use unique::Unique;
 use std::borrow::Borrow;
 use std::marker::PhantomData;
 use std::ptr;
-use std::ffi::{self, CString};
+use std::ffi::{self, CString, CStr};
 use std::path::Path;
 use std::slice;
 use std::ops::Deref;
@@ -744,7 +744,8 @@ fn cstr_to_string(ptr: *const libc::c_char) -> Result<Option<String>, Error> {
     let string = if ptr.is_null() {
         None
     } else {
-        Some(unsafe { CString::from_raw(ptr as _) }.into_string()?)
+        Some(unsafe {
+            CStr::from_ptr(ptr as _) .to_string_lossy().into_owned()})
     };
     Ok(string)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,10 @@ pub enum Error {
 
 impl Error {
     fn new(ptr: *const libc::c_char) -> Error {
-        unsafe { PcapError(CString::from_raw(ptr as *mut _).to_string_lossy().into_owned()) }
+        match cstr_to_string(ptr) {
+            Err(e) => e as Error,
+            Ok(string) => PcapError(string.unwrap_or_default()),
+        }
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -266,3 +266,10 @@ fn test_linktype() {
     assert_eq!(linktype.get_name().unwrap(), String::from("EN10MB"));
     assert!(linktype.get_description().is_ok());
 }
+
+#[test]
+fn test_error() {
+    let mut capture = capture_from_test_file("packet_snaplen_65535.pcap");
+    // Trying to get stats from offline capture should error.
+    assert!(capture.stats().err().is_some());
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -256,3 +256,13 @@ fn test_raw_fd_api() {
         packets.verify(&mut cap);
     }
 }
+
+#[test]
+fn test_linktype() {
+    let capture = capture_from_test_file("packet_snaplen_65535.pcap");
+    let linktype = capture.get_datalink();
+
+    assert!(linktype.get_name().is_ok());
+    assert_eq!(linktype.get_name().unwrap(), String::from("EN10MB"));
+    assert!(linktype.get_description().is_ok());
+}


### PR DESCRIPTION
Previously the code was using CString::from_raw, however that was unsafe https://doc.rust-lang.org/beta/std/ffi/struct.CString.html#safety-1 and was assuming it had ownership of the string.

I converted it to https://doc.rust-lang.org/std/ffi/struct.CStr.html and added tests for linktype to make sure that it works.