### PR TITLE
enable non blocking capture using selectable fd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -660,6 +660,25 @@ impl<T: Activated + ?Sized> Capture<T> {
                 .map(|_| Stat::new(stats.ps_recv, stats.ps_drop, stats.ps_ifdrop))
         }
     }
+
+    pub fn setnonblock(&self, non_blocking: bool) -> Result<(), Error> {
+        with_errbuf(|err| unsafe {
+
+            let nonblock: ::libc::c_int = if non_blocking { 1 } else { 0 };
+
+            if -1 == raw::pcap_setnonblock(*self.handle, nonblock, err) {
+                return Err(Error::new(err));
+            }
+            Ok(())
+        })
+    }
+
+    pub fn get_selectable_fd(&self) -> Result<RawFd, Error> {
+        unsafe {
+            let fd = raw::pcap_get_selectable_fd(*self.handle);
+            self.check_err(fd != -1).map(|_| fd as RawFd)
+        }
+    }
 }
 
 impl Capture<Active> {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -129,7 +129,7 @@ extern "C" {
     pub fn pcap_setfilter(arg1: *mut pcap_t, arg2: *mut bpf_program) -> c_int;
     pub fn pcap_setdirection(arg1: *mut pcap_t, arg2: pcap_direction_t) -> c_int;
     // pub fn pcap_getnonblock(arg1: *mut pcap_t, arg2: *mut c_char) -> c_int;
-    // pub fn pcap_setnonblock(arg1: *mut pcap_t, arg2: c_int, arg3: *mut c_char) -> c_int;
+    pub fn pcap_setnonblock(arg1: *mut pcap_t, arg2: c_int, arg3: *mut c_char) -> c_int;
     pub fn pcap_sendpacket(arg1: *mut pcap_t, arg2: *const c_uchar, arg3: c_int) -> c_int;
     // pub fn pcap_statustostr(arg1: c_int) -> *const c_char;
     // pub fn pcap_strerror(arg1: c_int) -> *const c_char;
@@ -170,7 +170,7 @@ extern "C" {
     // pub fn pcap_lib_version() -> *const c_char;
     // pub fn bpf_image(arg1: *const bpf_insn, arg2: c_int) -> *mut c_char;
     // pub fn bpf_dump(arg1: *const bpf_program, arg2: c_int) -> ();
-    // pub fn pcap_get_selectable_fd(arg1: *mut pcap_t) -> c_int;
+    pub fn pcap_get_selectable_fd(arg1: *mut pcap_t) -> c_int;
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
this pull enables  `set_nonblock` and `get_selectable_fd` so you can capture packets in an event loop

I have an example to use this using tokio. I'll put that in a separate pull request