### PR TITLE
use winapi on windows, update windows build instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ mio = { version = "0.6", optional = true }
 tokio-core = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = "0.2"
+
 [dev-dependencies]
 tempdir = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ See examples for usage.
 ## Windows
 
 Install [WinPcap](http://www.winpcap.org/install/default.htm).
-
-Place wpcap.dll in your `C:\Rust\bin\rustlib\x86_64-pc-windows-gnu\lib\` directory on 64 bit
-or `C:\Rust\bin\rustlib\i686-pc-windows-gnu\lib\` on 32 bit.
+Download the WinPcap [Developer's Pack](https://www.winpcap.org/devel.htm).
+Add the `/Lib` or `/Lib/x64` folder to your `LIB` environment variable.
 
 ## Linux
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ extern crate mio;
 extern crate futures;
 #[cfg(feature = "tokio")]
 extern crate tokio_core;
+#[cfg(target_os = "windows")]
+extern crate winapi;
 
 use unique::Unique;
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,7 +1,11 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
-use libc::{c_int, c_uint, c_char, c_uchar, c_ushort, sockaddr, timeval, FILE};
+use libc::{c_int, c_uint, c_char, c_uchar, c_ushort, timeval, FILE};
+#[cfg(target_os = "windows")]
+use winapi::ws2def::SOCKADDR as sockaddr;
+#[cfg(not(target_os = "windows"))]
+use libc::sockaddr;
 
 #[repr(C)]
 #[derive(Copy, Clone)]


### PR DESCRIPTION
After updating to 0.7.0 i encountered no more segfaults, so you might want this upstream.

Adds the dependency to winapi for `target_os = "windows"`, and uses its `sockaddr`. I also took the liberty and corrected the windows build instructions for MSVC.

fixes #70, fixes #73