### PR TITLE
add required feature to streamlisten example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,4 @@ path = "examples/getstatistics.rs"
 [[example]]
 name = "streamlisten"
 path = "examples/streamlisten.rs"
+required-features = ["tokio"]


### PR DESCRIPTION
`streamlisten` depended on optional crates, and was thus causing the build to fail if the feature was not enabled.


fixes #85