### PR TITLE
fix tests on windows (64bit MSVC)

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -61,8 +61,8 @@ impl Packets {
     }
 
     pub fn push(&mut self,
-                tv_sec: libc::time_t,
-                tv_usec: libc::suseconds_t,
+                tv_sec: libc::c_long,
+                tv_usec: libc::c_long,
                 caplen: u32,
                 len: u32,
                 data: &[u8]) {


### PR DESCRIPTION
Switching to a `c_long` (i32) should work on all platforms.

This PR depends on #83 and #86.
fixes #87.