### PR TITLE
fix clippy feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - {os: linux, rust: beta,
        env: FLAGS="--features tokio"}
     - {os: linux, rust: nightly,
-       env: FLAGS="--features clippy,tokio"}
+       env: FLAGS="--features clippy-lint,tokio"}
     - {os: osx, rust: stable,
        env: FLAGS="--features full" PCAP_LIBDIR=/usr/local/opt/libpcap/lib}
     - {os: osx, rust: beta,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ pcap-fopen-offline-precision = []
 # This is disabled by default, because it depends on a tokio and mio
 tokio = ["mio", "tokio-core", "futures"]
 
+# This feature enables clippy.
+clippy-lint = ["clippy"]
+
 # A shortcut to enable all features.
 full = ["pcap-savefile-append", "pcap-fopen-offline-precision", "tokio"]
 


### PR DESCRIPTION
The travis config tried to enable a feature named `clippy` that did not exist. Since we have a dependency called `clippy` we cannot define a feature named `clippy`, so i named it `clippy-lint`.


Fixes #82.