### PR TITLE
Expose pcap_compile: compile pcap expressions to bpf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,27 +41,3 @@ full = ["pcap-savefile-append", "pcap-fopen-offline-precision", "tokio"]
 
 [lib]
 name = "pcap"
-
-[[example]]
-name = "listenlocalhost"
-path = "examples/listenlocalhost.rs"
-
-[[example]]
-name = "getdevices"
-path = "examples/getdevices.rs"
-
-[[example]]
-name = "easylisten"
-path = "examples/easylisten.rs"
-
-[[example]]
-name = "savefile"
-path = "examples/savefile.rs"
-
-[[example]]
-name = "getstatistics"
-path = "examples/getstatistics.rs"
-
-[[example]]
-name = "streamlisten"
-path = "examples/streamlisten.rs"

--- a/examples/nfbpf_compile.rs
+++ b/examples/nfbpf_compile.rs
@@ -1,0 +1,52 @@
+///! nfbpf_compile works the same way as the small tool bundled with iptables:
+///! it compiles a pcap expression in to a BPF filter, then serializes it using
+///! a simple, safe encoding.
+///!
+
+extern crate pcap;
+
+use pcap::{Capture, Linktype};
+
+use std::env;
+use std::process;
+
+
+fn main() {
+    let (layertype, prog) = match env::args().len() {
+        2 => ("RAW".to_string(), env::args().nth(1).unwrap()),
+        3 => (env::args().nth(1).unwrap(), env::args().nth(2).unwrap()),
+        _ => {
+            println!("Usage:    {} [type] 'program'", env::args().nth(0).unwrap());
+            println!("  type: a pcap linklayer type, e.g:");
+            println!("      RAW, EN10MB");
+            println!("  program: a pcap filter expression e.g.:");
+            println!("      'tcp port 80'");
+            println!("      'host 10.0.0.5'");
+            println!("      'icmp and greater 1000'");
+            process::exit(1);
+        }
+    };
+
+    let lt = match Linktype::from_name(&layertype) {
+        Ok(t) => t,
+        Err(_) => {
+            println!("Invalid linklayer type {}", layertype);
+            process::exit(1);
+        },
+    };
+
+    let mut h = Capture::dead(lt).unwrap();
+
+    let p: Vec<pcap::bpf_insn> = match h.compile_filter(&prog) {
+        Ok(p) => p,
+        Err(e) => {
+            println!("{:?}", e);
+            process::exit(1);
+        }
+    };
+    let def: String = p.iter()
+        .map(|&op| format!("{} {} {} {}", op.code, op.jt, op.jf, op.k))
+        .collect::<Vec<_>>()
+        .join(",");
+    println!("{},{}",p.len(), def);
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -147,7 +147,7 @@ extern "C" {
     pub fn pcap_list_datalinks(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int;
     pub fn pcap_set_datalink(arg1: *mut pcap_t, arg2: c_int) -> c_int;
     pub fn pcap_free_datalinks(arg1: *mut c_int) -> ();
-    // pub fn pcap_datalink_name_to_val(arg1: *const c_char) -> c_int;
+    pub fn pcap_datalink_name_to_val(arg1: *const c_char) -> c_int;
     pub fn pcap_datalink_val_to_name(arg1: c_int) -> *const c_char;
     pub fn pcap_datalink_val_to_description(arg1: c_int) -> *const c_char;
     // pub fn pcap_snapshot(arg1: *mut pcap_t) -> c_int;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -273,3 +273,23 @@ fn test_error() {
     // Trying to get stats from offline capture should error.
     assert!(capture.stats().err().is_some());
 }
+
+
+#[test]
+fn test_compile_filter() {
+    let mut h = Capture::dead(Linktype(1)).unwrap();
+    let p = h.compile_filter("tcp port 80");
+    assert!(p.is_ok());
+    let p = p.unwrap();
+
+    assert_eq!(p.len(), 20);
+
+    // Serialize like nfbpf_compile
+    let def: String = p.iter()
+        .map(|&op| format!("{} {} {} {}", op.code, op.jt, op.jf, op.k))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let expected = "40 0 0 12,21 0 6 34525,48 0 0 20,21 0 15 6,40 0 0 54,21 12 0 80,40 0 0 56,21 10 11 80,21 0 10 2048,48 0 0 23,21 0 8 6,40 0 0 20,69 6 0 8191,177 0 0 14,72 0 0 14,21 2 0 80,72 0 0 16,21 0 1 80,6 0 0 65535,6 0 0 0";
+    assert_eq!(def, expected);
+}


### PR DESCRIPTION
This exposes pcap_compile, which is used in many libraries to compile pcap expressions to a bpf payload.

Also, remove explicit example listing; they're not needed anymore.