### PR TITLE
pkg-config support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ futures = { version = "0.1", optional = true }
 [dev-dependencies]
 tempdir = "0.3"
 
+[build-dependencies]
+pkg-config = "0.3.16"
+
 [features]
 # This feature enables access to the function Capture::savefile_append.
 # This is disabled by default, because it depends on a relatively recent

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,14 @@
 use std::env;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if pkg_config::Config::new().cargo_metadata(true).probe("libpcap").is_ok() {
+        println!("cargo:rustc-cfg=has_pkg_config");
+        return
+    }
+
+    println!("cargo:rerun-if-env-changed=PCAP_LIBDIR");
     if let Ok(libdir) = env::var("PCAP_LIBDIR") {
         println!("cargo:rustc-link-search=native={}", libdir);
     }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -177,8 +177,9 @@ extern "C" {
 #[link(name = "wpcap")]
 extern "C" {}
 
+#[cfg_attr(not(any(windows, has_pkg_config)), link(name = "pcap"))]
+
 #[cfg(not(windows))]
-#[link(name = "pcap")]
 extern "C" {
     // pub fn pcap_inject(arg1: *mut pcap_t, arg2: *const c_void, arg3: size_t) -> c_int;
     pub fn pcap_set_rfmon(arg1: *mut pcap_t, arg2: c_int) -> c_int;


### PR DESCRIPTION
`pkg-config` is the de-facto standard to retrieve compile and link information regarding system packages.

This PR adds basic support for pkg-config, while maintaining old behaviour for systems without pkg-config and particularly windows.