### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
     - {os: linux, rust: beta,
        env: FLAGS="--features tokio"}
     - {os: linux, rust: nightly,
-       env: FLAGS="--features clippy,tokio"}
+       env: FLAGS="--features tokio"}
     - {os: osx, rust: stable,
        env: FLAGS="--features full" PCAP_LIBDIR=/usr/local/opt/libpcap/lib}
     - {os: osx, rust: beta,
@@ -26,7 +26,10 @@ before_install:
         brew install libpcap;
         ;;
     esac
+before_script:
+  - rustup component add clippy
 script:
-  - cargo build -v $FLAGS 
+  - cargo build -v $FLAGS
   - cargo test  -v $FLAGS
+  - cargo clippy
   - cargo doc --no-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: rust
-sudo: false
+os: linux
+dist: bionic
 addons:
   apt:
     packages: [libpcap0.8, libpcap0.8-dev]
-matrix:
+jobs:
   include:
     - {os: linux, rust: stable,
        env: FLAGS="--features tokio"}
@@ -18,10 +19,13 @@ matrix:
     - {os: osx, rust: nightly,
        env: FLAGS="--all-features" PCAP_LIBDIR=/usr/local/opt/libpcap/lib}
 before_install:
-  - if [ `uname` = "Darwin" ]; then
-      brew update >/dev/null;
-      brew install homebrew/dupes/libpcap;
-    fi
+- |-
+    case $TRAVIS_OS_NAME in
+      osx)
+        brew update >/dev/null;
+        brew install libpcap;
+        ;;
+    esac
 script:
   - cargo build -v $FLAGS 
   - cargo test  -v $FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,10 @@ jobs:
        env: FLAGS="--features tokio"}
     - {os: linux, rust: beta,
        env: FLAGS="--features tokio"}
-    - {os: linux, rust: nightly,
-       env: FLAGS="--features tokio"}
     - {os: osx, rust: stable,
        env: FLAGS="--features full" PCAP_LIBDIR=/usr/local/opt/libpcap/lib}
     - {os: osx, rust: beta,
        env: FLAGS="--features full" PCAP_LIBDIR=/usr/local/opt/libpcap/lib}
-    - {os: osx, rust: nightly,
-       env: FLAGS="--all-features" PCAP_LIBDIR=/usr/local/opt/libpcap/lib}
 before_install:
 - |-
     case $TRAVIS_OS_NAME in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,4 @@ path = "examples/getstatistics.rs"
 [[example]]
 name = "streamlisten"
 path = "examples/streamlisten.rs"
+required-features = ["tokio"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ impl std::error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             MalformedError(ref e) => Some(e),
             _ => None,
@@ -778,8 +778,8 @@ impl<T: State + ? Sized> Drop for Capture<T> {
     }
 }
 
-impl<T: Activated> From<Capture<T>> for Capture<Activated> {
-    fn from(cap: Capture<T>) -> Capture<Activated> {
+impl<T: Activated> From<Capture<T>> for Capture<dyn Activated> {
+    fn from(cap: Capture<T>) -> Capture<dyn Activated> {
         unsafe { mem::transmute(cap) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,6 @@
 //! }
 //! ```
 
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
-#![cfg_attr(feature = "clippy", allow(redundant_closure_call))]
-
 extern crate libc;
 #[cfg(feature = "tokio")]
 extern crate mio;
@@ -644,7 +640,7 @@ impl<T: Activated + ? Sized> Capture<T> {
     /// from. This buffer has a finite length, so if the buffer fills completely new
     /// packets will be discarded temporarily. This means that in realtime situations,
     /// you probably want to minimize the time between calls of this next() method.
-    #[cfg_attr(feature = "clippy", allow(should_implement_trait))]
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Result<Packet, Error> {
         unsafe {
             let mut header: *mut raw::pcap_pkthdr = ptr::null_mut();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -37,11 +37,11 @@ fn unify_activated() {
         loop {}
     }
 
-    fn maybe(a: bool) -> Capture<Activated> {
+    fn maybe(a: bool) -> Capture<dyn Activated> {
         if a { test1().into() } else { test2().into() }
     }
 
-    fn also_maybe(a: &mut Capture<Activated>) {
+    fn also_maybe(a: &mut Capture<dyn Activated>) {
         a.filter("whatever filter string, this won't be run anyway").unwrap();
     }
 }


### PR DESCRIPTION
Fix and update Travis build:

1. Fix causes of failure: homebrew and required feature for `streamlisten` example.
2. Fix how clippy is run. Current advice is to run as `cargo` command, not a feature.
3. Remove nightly builds as they are unnecessary and time will be better spent adding windows builds.

The PR also slightly reformats a few things to make it easier to add Windows builds.

@sekineh I will leave the windows build setup to you, but this is what I set up on my branch: https://github.com/Wojtek242/pcap/blob/master/.travis.yml but I'm not a windows dev so there might be better ways of getting it done. I had quite the headache getting winpcap installed (chocolate install wasn't working for whatever reason).

This PR will be followed by a few more from my branch. Having builds working would make that easier.