### PR TITLE
Tokio update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ addons:
 jobs:
   include:
     - {os: linux, rust: stable,
-       env: FLAGS="--features tokio"}
+       env: FLAGS="--features capture-stream"}
     - {os: linux, rust: beta,
-       env: FLAGS="--features tokio"}
+       env: FLAGS="--features capture-stream"}
     - {os: osx, rust: stable,
        env: FLAGS="--features full" PCAP_LIBDIR=/usr/local/opt/libpcap/lib}
     - {os: osx, rust: beta,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Opt into Rust 2018.
 - Updated dependency from deprecated `tokio-core` to `tokio` 0.2.
 - Updated dependency `futures` from version 0.1 to 0.3.
 - Feature `tokio` renamed to `capture-stream` because Cargo does not allow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+
+- Updated dependency from deprecated `tokio-core` to `tokio` 0.2.
+- Updated dependency `futures` from version 0.1 to 0.3.
+- Feature `tokio` renamed to `capture-stream` because Cargo does not allow
+  features and dependencies to have the same name.
+
+## [0.7.0] - 2017-08-04
+
+No Changelog entries for <= 0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ build = "build.rs"
 libc = "0.2"
 clippy = { version = "0.0.*", optional = true }
 mio = { version = "0.6", optional = true }
-tokio = { version = "0.2", optional = true }
+tokio = { version = "0.2", features = ["io-driver"], optional = true }
 futures = { version = "0.3", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2"
 clippy = { version = "0.0.*", optional = true }
 mio = { version = "0.6", optional = true }
 tokio-core = { version = "0.1", optional = true }
-futures = { version = "0.1", optional = true }
+futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ build = "build.rs"
 libc = "0.2"
 clippy = { version = "0.0.*", optional = true }
 mio = { version = "0.6", optional = true }
-tokio-core = { version = "0.1", optional = true }
+tokio = { version = "0.2", optional = true }
 futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
@@ -34,10 +34,10 @@ pcap-fopen-offline-precision = []
 
 # This feature enables access to the function Capture::stream.
 # This is disabled by default, because it depends on a tokio and mio
-tokio = ["mio", "tokio-core", "futures"]
+capture-stream = ["mio", "tokio", "futures"]
 
 # A shortcut to enable all features.
-full = ["pcap-savefile-append", "pcap-fopen-offline-precision", "tokio"]
+full = ["pcap-savefile-append", "pcap-fopen-offline-precision", "capture-stream"]
 
 [lib]
 name = "pcap"
@@ -65,4 +65,4 @@ path = "examples/getstatistics.rs"
 [[example]]
 name = "streamlisten"
 path = "examples/streamlisten.rs"
-required-features = ["tokio"]
+required-features = ["capture-stream"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 name = "pcap"
 version = "0.7.0"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
+edition = "2018"
 description = "A packet capture API around pcap/wpcap"
 keywords = ["pcap", "packet", "sniffing"]
 readme = "README.md"
@@ -21,6 +22,7 @@ futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3"
+tokio = { version = "0.2", features = ["rt-core"] }
 
 [features]
 # This feature enables access to the function Capture::savefile_append.

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ If `PCAP_LIBDIR` environment variable is set when building the crate, it will be
 
 ## Optional Features
 
-#### `tokio`
+#### `capture-stream`
 
-Use the `tokio` feature to enable support for streamed packet captures.
+Use the `capture-stream` feature to enable support for streamed packet captures.
 
 ```toml
 [dependencies]
-pcap = { version = "0.7", features = ["tokio"] }
+pcap = { version = "0.7", features = ["capture-stream"] }
 ```
 
 #### `pcap-savefile-append`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ See examples for usage.
 
 # Building
 
+As of 0.8.0 This crate uses Rust 2018 and thus requires a compiler version >= 1.31.
+
 ## Windows
 
 Install [WinPcap](http://www.winpcap.org/install/default.htm).

--- a/examples/easylisten.rs
+++ b/examples/easylisten.rs
@@ -1,5 +1,3 @@
-extern crate pcap;
-
 fn main() {
     // get the default Device
     let mut cap = pcap::Device::lookup().unwrap().open().unwrap();

--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -1,5 +1,3 @@
-extern crate pcap;
-
 fn main() {
     // list all of the devices pcap tells us are available
     for device in pcap::Device::list().unwrap() {

--- a/examples/getstatistics.rs
+++ b/examples/getstatistics.rs
@@ -1,5 +1,3 @@
-extern crate pcap;
-
 fn main() {
     // get the default Device
     let mut cap = pcap::Device::lookup().unwrap().open().unwrap();

--- a/examples/listenlocalhost.rs
+++ b/examples/listenlocalhost.rs
@@ -1,5 +1,3 @@
-extern crate pcap;
-
 fn main() {
     // listen on the device named "any", which is only available on Linux. This is only for
     // demonstration purposes.

--- a/examples/savefile.rs
+++ b/examples/savefile.rs
@@ -1,5 +1,3 @@
-extern crate pcap;
-
 use pcap::*;
 
 fn main() {

--- a/examples/streamlisten.rs
+++ b/examples/streamlisten.rs
@@ -1,7 +1,3 @@
-extern crate futures;
-extern crate pcap;
-extern crate tokio;
-
 use futures::StreamExt;
 use pcap::stream::{PacketCodec, PacketStream};
 use pcap::{Active, Capture, Device, Error, Packet};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,12 +47,12 @@
 //! ```
 
 extern crate libc;
-#[cfg(feature = "tokio")]
+#[cfg(feature = "capture-stream")]
 extern crate mio;
-#[cfg(feature = "tokio")]
+#[cfg(feature = "capture-stream")]
 extern crate futures;
-#[cfg(feature = "tokio")]
-extern crate tokio_core;
+#[cfg(feature = "capture-stream")]
+extern crate tokio;
 
 use unique::Unique;
 
@@ -65,7 +65,7 @@ use std::slice;
 use std::ops::Deref;
 use std::mem;
 use std::fmt;
-#[cfg(feature = "tokio")]
+#[cfg(feature = "capture-stream")]
 use std::io;
 #[cfg(not(windows))]
 use std::os::unix::io::{RawFd, AsRawFd};
@@ -74,8 +74,8 @@ use self::Error::*;
 
 mod raw;
 mod unique;
-#[cfg(feature = "tokio")]
-pub mod tokio;
+#[cfg(feature = "capture-stream")]
+pub mod stream;
 
 /// An error received from pcap
 #[derive(Debug, PartialEq)]
@@ -671,8 +671,8 @@ impl<T: Activated + ? Sized> Capture<T> {
         }
     }
 
-    #[cfg(feature = "tokio")]
-    fn next_noblock<'a>(&'a mut self, fd: &mut tokio_core::reactor::PollEvented<tokio::SelectableFd>) -> Result<Packet<'a>, Error> {
+    #[cfg(feature = "capture-stream")]
+    fn next_noblock<'a>(&'a mut self, fd: &mut tokio::reactor::PollEvented<stream::SelectableFd>) -> Result<Packet<'a>, Error> {
         if let futures::task::Poll::Pending = fd.poll_read() {
             return Err(IoError(io::ErrorKind::WouldBlock))
         } else {
@@ -687,14 +687,14 @@ impl<T: Activated + ? Sized> Capture<T> {
         }
     }
 
-    #[cfg(feature = "tokio")]
-    pub fn stream<C: tokio::PacketCodec>(self, handle: &tokio_core::reactor::Handle, codec: C) -> Result<tokio::PacketStream<T, C>, Error> {
+    #[cfg(feature = "capture-stream")]
+    pub fn stream<C: stream::PacketCodec>(self, handle: &tokio::reactor::Handle, codec: C) -> Result<stream::PacketStream<T, C>, Error> {
         if !self.nonblock {
             return Err(NonNonBlock);
         }
         unsafe {
             let fd = raw::pcap_get_selectable_fd(*self.handle);
-            tokio::PacketStream::new(self, fd, handle, codec)
+            stream::PacketStream::new(self, fd, handle, codec)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -673,7 +673,7 @@ impl<T: Activated + ? Sized> Capture<T> {
 
     #[cfg(feature = "tokio")]
     fn next_noblock<'a>(&'a mut self, fd: &mut tokio_core::reactor::PollEvented<tokio::SelectableFd>) -> Result<Packet<'a>, Error> {
-        if let futures::Async::NotReady = fd.poll_read() {
+        if let futures::task::Poll::Pending = fd.poll_read() {
             return Err(IoError(io::ErrorKind::WouldBlock))
         } else {
             return match self.next() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,14 +46,6 @@
 //! }
 //! ```
 
-extern crate libc;
-#[cfg(feature = "capture-stream")]
-extern crate mio;
-#[cfg(feature = "capture-stream")]
-extern crate futures;
-#[cfg(feature = "capture-stream")]
-extern crate tokio;
-
 use unique::Unique;
 
 use std::borrow::Borrow;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -10,7 +10,7 @@ use super::Packet;
 use super::Error;
 use super::State;
 use super::Capture;
-use tokio_core;
+use tokio;
 use futures;
 
 pub struct SelectableFd {
@@ -42,13 +42,13 @@ pub trait PacketCodec {
 
 pub struct PacketStream<T: State + ? Sized, C> {
     cap: Capture<T>,
-    fd: tokio_core::reactor::PollEvented<SelectableFd>,
+    fd: tokio::reactor::PollEvented<SelectableFd>,
     codec: C,
 }
 
 impl<T: Activated + ? Sized, C: PacketCodec> PacketStream<T, C> {
-    pub fn new(cap: Capture<T>, fd: RawFd, handle: &tokio_core::reactor::Handle, codec: C) -> Result<PacketStream<T, C>, Error> {
-        Ok(PacketStream { cap: cap, fd: tokio_core::reactor::PollEvented::new(SelectableFd { fd: fd }, handle)?, codec: codec })
+    pub fn new(cap: Capture<T>, fd: RawFd, handle: &tokio::reactor::Handle, codec: C) -> Result<PacketStream<T, C>, Error> {
+        Ok(PacketStream { cap: cap, fd: tokio::reactor::PollEvented::new(SelectableFd { fd: fd }, handle)?, codec: codec })
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,3 @@
-extern crate pcap;
-extern crate libc;
-extern crate tempdir;
-
 use std::io;
 use std::ops::Add;
 use std::path::Path;


### PR DESCRIPTION
Update `futures` and `tokio` to latest versions.

Closes #108 and #99 (which only updates to `tokio` 0.1 and doesn't update futures).