### PR TITLE
Github Actions for Windows CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,21 +16,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install npcap sdk
+    - name: Install WinPcap 4.1.3
+      run: cinst -y winpcap --version 4.1.3.20161116
+    - name: Install WinPcap 4.1.2 Developer's Pack
       shell: bash
       run: |
-        mkdir $TEMP/npcap-sdk
-        pushd $TEMP/npcap-sdk
-        curl -O https://nmap.org/npcap/dist/npcap-sdk-1.05.zip
-        7z x npcap-sdk-1.05.zip -o.
-        ls -l $TEMP/npcap-sdk/Lib/x64
-        # echo "::set-env LIB=$LIB:$TEMP/npcap-sdk/Lib/x64"
+        mkdir $TEMP/winpcap-dp
+        pushd $TEMP/winpcap-dp
+        curl -O https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip
+        7z x WpdPack_4_1_2.zip -o.
+        ls -l WpdPack/Lib/x64
+        # echo "::set-env LIB=$LIB:$TEMP/winpcap-dp/WpdPack/Lib/x64"
         popd
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       shell: bash
-      run: env LIB=$TEMP/npcap-sdk/Lib/x64/ cargo test --verbose
+      run: env LIB=$TEMP/winpcap-dp/Lib/x64/ cargo test --verbose
     - name: Clean up
       shell: bash
-      run: rm -r $TEMP/npcap-sdk
+      run: rm -r $TEMP/winpcap-dp

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,18 +21,18 @@ jobs:
     - name: Install WinPcap 4.1.2 Developer's Pack
       shell: bash
       run: |
-        mkdir $TEMP/winpcap-dp
-        pushd $TEMP/winpcap-dp
+        mkdir /c/winpcap-dp
+        pushd /c/winpcap-dp
         curl -O https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip
         7z x WpdPack_4_1_2.zip -o.
         ls -l WpdPack/Lib/x64
-        # echo "::set-env LIB=$LIB:$TEMP/winpcap-dp/WpdPack/Lib/x64"
+        # echo "::set-env LIB=$LIB:/c/winpcap-dp/WpdPack/Lib/x64"
         popd
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       shell: bash
-      run: env LIB=$TEMP/winpcap-dp/Lib/x64/ cargo test --verbose
+      run: env LIB='c:\winpcap-dp\WpdPack\Lib\x64' cargo test --verbose
     - name: Clean up
       shell: bash
-      run: rm -r $TEMP/winpcap-dp
+      run: rm -r /c/winpcap-dp

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  LIB: 'c:\winpcap-dp\WpdPack\Lib\x64'
 
 jobs:
   build:
@@ -28,11 +29,21 @@ jobs:
         ls -l WpdPack/Lib/x64
         # echo "::set-env LIB=$LIB:/c/winpcap-dp/WpdPack/Lib/x64"
         popd
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      shell: bash
-      run: env LIB='c:\winpcap-dp\WpdPack\Lib\x64' cargo test --verbose
+    - name: Build and Test (default)
+      run: |
+        cargo build --verbose
+        cargo test --verbose
+        cargo clean
+    - name: Build and Test (tokio)
+      run: |
+        cargo build --verbose --features tokio
+        cargo test --verbose --features tokio
+        cargo clean
+    - name: Build and Test (full)
+      run: |
+        cargo build --verbose --features full
+        cargo test --verbose --features full
+        cargo clean
     - name: Clean up
       shell: bash
       run: rm -r /c/winpcap-dp

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install npcap sdk
+      shell: bash
+      run: |
+        mkdir $TEMP/whatever
+        curl -O https://nmap.org/npcap/dist/npcap-sdk-1.05.zip
+        7z x npcap-sdk-1.05.zip -o$TEMP/whatever
+        ls $TEMP/whatever/Lib/x64
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      shell: bash
+      run: env LIB=$TEMP/whatever/Lib/x64/ cargo test --verbose
+    - name: Clean up
+      shell: bash
+      run: rm -r $TEMP/whatever

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,15 +19,18 @@ jobs:
     - name: Install npcap sdk
       shell: bash
       run: |
-        mkdir $TEMP/whatever
+        mkdir $TEMP/npcap-sdk
+        pushd $TEMP/npcap-sdk
         curl -O https://nmap.org/npcap/dist/npcap-sdk-1.05.zip
-        7z x npcap-sdk-1.05.zip -o$TEMP/whatever
-        ls $TEMP/whatever/Lib/x64
+        7z x npcap-sdk-1.05.zip -o.
+        ls -l $TEMP/npcap-sdk/Lib/x64
+        # echo "::set-env LIB=$LIB:$TEMP/npcap-sdk/Lib/x64"
+        popd
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       shell: bash
-      run: env LIB=$TEMP/whatever/Lib/x64/ cargo test --verbose
+      run: env LIB=$TEMP/npcap-sdk/Lib/x64/ cargo test --verbose
     - name: Clean up
       shell: bash
-      run: rm -r $TEMP/whatever
+      run: rm -r $TEMP/npcap-sdk

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ See examples for usage.
 
 Install [WinPcap](http://www.winpcap.org/install/default.htm).
 
-Place wpcap.dll in your `C:\Rust\bin\rustlib\x86_64-pc-windows-gnu\lib\` directory on 64 bit
-or `C:\Rust\bin\rustlib\i686-pc-windows-gnu\lib\` on 32 bit.
+Download the WinPcap [Developer's Pack](https://www.winpcap.org/devel.htm).
+Add the `/Lib` or `/Lib/x64` folder to your `LIB` environment variable.
 
 ## Linux
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -61,8 +61,8 @@ impl Packets {
     }
 
     pub fn push(&mut self,
-                tv_sec: libc::time_t,
-                tv_usec: libc::suseconds_t,
+                tv_sec: libc::c_long,
+                tv_usec: libc::c_long,
                 caplen: u32,
                 len: u32,
                 data: &[u8]) {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,6 +9,16 @@ use tempdir::TempDir;
 
 use pcap::{Active, Activated, Offline, Capture, Packet, PacketHeader, Linktype, Precision, Error};
 
+#[cfg(not(windows))]
+type time_t = libc::time_t;
+#[cfg(windows)]
+type time_t = libc::c_long;
+
+#[cfg(not(windows))]
+type suseconds_t = libc::suseconds_t;
+#[cfg(windows)]
+type suseconds_t = libc::c_long;
+
 #[test]
 fn read_packet_with_full_data() {
     let mut capture = capture_from_test_file("packet_snaplen_65535.pcap");
@@ -61,8 +71,8 @@ impl Packets {
     }
 
     pub fn push(&mut self,
-                tv_sec: libc::c_long,
-                tv_usec: libc::c_long,
+                tv_sec: time_t,
+                tv_usec: suseconds_t,
                 caplen: u32,
                 len: u32,
                 data: &[u8]) {
@@ -163,8 +173,8 @@ fn test_raw_fd_api() {
     let data: Vec<u8> = (0..191).cycle().take(N_PACKETS * 1024).collect();
     let mut packets = Packets::new();
     for i in 0..N_PACKETS {
-        packets.push(1460408319 + i as libc::time_t,
-                     1000 + i as libc::suseconds_t,
+        packets.push(1460408319 + i as time_t,
+                     1000 + i as suseconds_t,
                      1024,
                      1024,
                      &data[i * 1024..(i + 1) * 1024]);


### PR DESCRIPTION
Closes #113

This PR will enable CI test on Windows platform using GitHub actions. It builds and tests in three feature configurations:
- default features (no `--features` flag)
- `--features tokio`
- `--features full`

Used pcap version is:
- WinPcap 4.1.3 + WpdPack 4.1.2 (`npcap` is not tested in CI because It does not support silent install.)

Other notes:
- Parallel build is easy but we didn't do that.  `WinPcap` installation is `AutoHotKey`-based and takes more than 3.5 min.  I don't want to replicate this cpu time.  GHA free tier permits 2000 min / month for linux but for Windows, the limit is 1000 min / month.
  - https://docs.github.com/ja/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions