### PR TITLE
Fix all clippy and compiler warnings and add clippy to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,3 +47,5 @@ jobs:
           override: true
       - name: cargo test
         run: cargo test ${{ matrix.profile }} ${{ matrix.features }}
+      - name: cargo clippy
+        run: cargo clippy ${{ matrix.profile }} ${{ matrix.features }} -- -D warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ before_script:
 script:
   - cargo build -v $FLAGS
   - cargo test  -v $FLAGS
-  - cargo clippy
+  - cargo clippy -v $FLAGS -- -D warnings
   - cargo doc --no-deps

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -100,7 +100,7 @@ extern "C" {
     // pub fn pcap_get_tstamp_precision(arg1: *mut pcap_t) -> c_int;
     pub fn pcap_activate(arg1: *mut pcap_t) -> c_int;
     // pub fn pcap_list_tstamp_types(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int;
-    // pub fn pcap_free_tstamp_types(arg1: *mut c_int) -> ();
+    // pub fn pcap_free_tstamp_types(arg1: *mut c_int);
     // pub fn pcap_tstamp_type_name_to_val(arg1: *const c_char) -> c_int;
     // pub fn pcap_tstamp_type_val_to_name(arg1: c_int) -> *const c_char;
     // pub fn pcap_tstamp_type_val_to_description(arg1: c_int) -> *const c_char;
@@ -116,7 +116,7 @@ extern "C" {
     pub fn pcap_fopen_offline_with_tstamp_precision(arg1: *mut FILE, arg2: c_uint,
                                                     arg3: *mut c_char) -> *mut pcap_t;
     pub fn pcap_fopen_offline(arg1: *mut FILE, arg2: *mut c_char) -> *mut pcap_t;
-    pub fn pcap_close(arg1: *mut pcap_t) -> ();
+    pub fn pcap_close(arg1: *mut pcap_t);
     // pub fn pcap_loop(arg1: *mut pcap_t, arg2: c_int,
     //                  arg3: pcap_handler, arg4: *mut c_uchar) -> c_int;
     // pub fn pcap_dispatch(arg1: *mut pcap_t, arg2: c_int, arg3: pcap_handler,
@@ -124,7 +124,7 @@ extern "C" {
     // pub fn pcap_next(arg1: *mut pcap_t, arg2: *mut pcap_pkthdr) -> *const c_uchar;
     pub fn pcap_next_ex(arg1: *mut pcap_t, arg2: *mut *mut pcap_pkthdr,
                         arg3: *mut *const c_uchar) -> c_int;
-    // pub fn pcap_breakloop(arg1: *mut pcap_t) -> ();
+    // pub fn pcap_breakloop(arg1: *mut pcap_t);
     pub fn pcap_stats(arg1: *mut pcap_t, arg2: *mut pcap_stat) -> c_int;
     pub fn pcap_setfilter(arg1: *mut pcap_t, arg2: *mut bpf_program) -> c_int;
     pub fn pcap_setdirection(arg1: *mut pcap_t, arg2: pcap_direction_t) -> c_int;
@@ -134,19 +134,19 @@ extern "C" {
     // pub fn pcap_statustostr(arg1: c_int) -> *const c_char;
     // pub fn pcap_strerror(arg1: c_int) -> *const c_char;
     pub fn pcap_geterr(arg1: *mut pcap_t) -> *mut c_char;
-    // pub fn pcap_perror(arg1: *mut pcap_t, arg2: *mut c_char) -> ();
+    // pub fn pcap_perror(arg1: *mut pcap_t, arg2: *mut c_char);
     pub fn pcap_compile(arg1: *mut pcap_t, arg2: *mut bpf_program, arg3: *const c_char,
                         arg4: c_int, arg5: c_uint) -> c_int;
     // pub fn pcap_compile_nopcap(arg1: c_int, arg2: c_int, arg3: *mut bpf_program,
     //                            arg4: *const c_char, arg5: c_int, arg6: c_uint) -> c_int;
-    pub fn pcap_freecode(arg1: *mut bpf_program) -> ();
+    pub fn pcap_freecode(arg1: *mut bpf_program);
     // pub fn pcap_offline_filter(arg1: *const bpf_program, arg2: *const pcap_pkthdr,
     //                            arg3: *const c_uchar) -> c_int;
     pub fn pcap_datalink(arg1: *mut pcap_t) -> c_int;
     // pub fn pcap_datalink_ext(arg1: *mut pcap_t) -> c_int;
     pub fn pcap_list_datalinks(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int;
     pub fn pcap_set_datalink(arg1: *mut pcap_t, arg2: c_int) -> c_int;
-    pub fn pcap_free_datalinks(arg1: *mut c_int) -> ();
+    pub fn pcap_free_datalinks(arg1: *mut c_int);
     // pub fn pcap_datalink_name_to_val(arg1: *const c_char) -> c_int;
     pub fn pcap_datalink_val_to_name(arg1: c_int) -> *const c_char;
     pub fn pcap_datalink_val_to_description(arg1: c_int) -> *const c_char;
@@ -163,13 +163,13 @@ extern "C" {
     // pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut FILE;
     // pub fn pcap_dump_ftell(arg1: *mut pcap_dumper_t) -> c_long;
     // pub fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> c_int;
-    pub fn pcap_dump_close(arg1: *mut pcap_dumper_t) -> ();
-    pub fn pcap_dump(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar) -> ();
+    pub fn pcap_dump_close(arg1: *mut pcap_dumper_t);
+    pub fn pcap_dump(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar);
     pub fn pcap_findalldevs(arg1: *mut *mut pcap_if_t, arg2: *mut c_char) -> c_int;
-    pub fn pcap_freealldevs(arg1: *mut pcap_if_t) -> ();
+    pub fn pcap_freealldevs(arg1: *mut pcap_if_t);
     // pub fn pcap_lib_version() -> *const c_char;
     // pub fn bpf_image(arg1: *const bpf_insn, arg2: c_int) -> *mut c_char;
-    // pub fn bpf_dump(arg1: *const bpf_program, arg2: c_int) -> ();
+    // pub fn bpf_dump(arg1: *const bpf_program, arg2: c_int);
     pub fn pcap_get_selectable_fd(arg1: *mut pcap_t) -> c_int;
 }
 

--- a/src/unique.rs
+++ b/src/unique.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 
 use std::fmt;
-use std::mem;
 use std::marker::PhantomData;
 use std::ops::Deref;
 
@@ -33,7 +32,7 @@ impl<T: ?Sized> Deref for Unique<T> {
 
     #[inline]
     fn deref(&self) -> &*mut T {
-        unsafe { mem::transmute(&self.pointer) }
+        unsafe { &*(&self.pointer as *const *const T as *const *mut T) }
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,18 +1,25 @@
+#[cfg(not(windows))]
 use std::io;
 use std::ops::Add;
 use std::path::Path;
 use tempdir::TempDir;
 
-use pcap::{Active, Activated, Offline, Capture, Packet, PacketHeader, Linktype, Precision, Error};
+use pcap::{Active, Activated, Offline, Capture, Packet, PacketHeader, Linktype};
+#[cfg(not(windows))]
+use pcap::{Precision, Error};
 
 #[cfg(not(windows))]
+#[allow(non_camel_case_types)]
 type time_t = libc::time_t;
 #[cfg(windows)]
+#[allow(non_camel_case_types)]
 type time_t = libc::c_long;
 
 #[cfg(not(windows))]
+#[allow(non_camel_case_types)]
 type suseconds_t = libc::suseconds_t;
 #[cfg(windows)]
+#[allow(non_camel_case_types)]
 type suseconds_t = libc::c_long;
 
 #[test]


### PR DESCRIPTION
This PR fixes all clippy and compiler warnings. I've also added clippy to GitHub actions with the flag `-D warnings` which means the run will fail for any clippy warning.

Closes #114 