### PR TITLE
Fix double close

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -248,7 +248,6 @@ fn test_raw_fd_api() {
             let mut file_in = File::open(&filename).unwrap();
             let mut file_out = unsafe { File::from_raw_fd(fd_out) };
             io::copy(&mut file_in, &mut file_out).unwrap();
-            assert_eq!(unsafe { libc::close(fd_out) }, 0);
         });
 
         // Open the capture with pipe's file descriptor


### PR DESCRIPTION
When `file_out` goes out of scope it closes `fd_out`, but it is also closed explicitly:
https://github.com/ebfull/pcap/blob/1e878474fa35fc0cb796d248bf3e373482716a3b/tests/lib.rs#L244-L259

If the second closing happens after the call to `Capture::from_raw_fd`, the fd number was reused and the capture's file handle is being closed while it is still used.

Fixes #119