### PR TITLE
Add minimum supported rustc version.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.39.0", stable]
+        toolchain: ["1.40.0", stable]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.40.0", stable, beta]
+        toolchain: ["1.43.1", stable, beta]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: [1.40, stable, beta]
+        toolchain: ["1.40", stable, beta]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.38.0", stable]
+        toolchain: ["1.39.0", stable]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.40", stable, beta]
+        toolchain: ["1.40.0", stable, beta]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.44.1", stable, beta]
+        toolchain: ["1.37.0", stable, beta]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: [stable, beta]
+        toolchain: [1.40, stable, beta]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,7 @@ jobs:
       - name: cargo test
         run: cargo test ${{ matrix.profile }} ${{ matrix.features }}
       - name: cargo clippy
+        if: matrix.toolchain == 'stable'
         run: cargo clippy ${{ matrix.profile }} ${{ matrix.features }} -- -D warnings
       - name: cargo doc
         run: cargo doc ${{ matrix.profile }} ${{ matrix.features }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.40.0", stable, beta]
+        toolchain: ["1.38.0", stable]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.37.0", stable, beta]
+        toolchain: ["1.40.0", stable, beta]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
           override: true
+      - name: cargo build
+        run: cargo build ${{ matrix.profile }} ${{ matrix.features }}
       - name: cargo test
         run: cargo test ${{ matrix.profile }} ${{ matrix.features }}
       - name: cargo clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.40.0", stable]
+        toolchain: ["1.40.0", stable, beta]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.43.1", stable, beta]
+        toolchain: ["1.44.1", stable, beta]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Opt into Rust 2018.
-- Now minimum supported rustc version is 1.44.1.
+- Now minimum supported rustc version is 1.40.0.
 - Updated dependency from deprecated `tokio-core` to `tokio` 0.2.
 - Updated dependency `futures` from version 0.1 to 0.3.
 - Feature `tokio` renamed to `capture-stream` because Cargo does not allow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Opt into Rust 2018.
+- Now minimum supported rustc version is 1.44.1.
 - Updated dependency from deprecated `tokio-core` to `tokio` 0.2.
 - Updated dependency `futures` from version 0.1 to 0.3.
 - Feature `tokio` renamed to `capture-stream` because Cargo does not allow

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See examples for usage.
 
 # Building
 
-As of 0.8.0 This crate uses Rust 2018 and requires a compiler version >= 1.43.1.
+As of 0.8.0 This crate uses Rust 2018 and requires a compiler version >= 1.44.1.
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See examples for usage.
 
 # Building
 
-As of 0.8.0 This crate uses Rust 2018 and requires a compiler version >= 1.44.1.
+As of 0.8.0 This crate uses Rust 2018 and requires a compiler version >= 1.40.0.
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See examples for usage.
 
 # Building
 
-As of 0.8.0 This crate uses Rust 2018 and requires a compiler version >= 1.40.
+As of 0.8.0 This crate uses Rust 2018 and requires a compiler version >= 1.40.0.
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See examples for usage.
 
 # Building
 
-As of 0.8.0 This crate uses Rust 2018 and thus requires a compiler version >= 1.31.
+As of 0.8.0 This crate uses Rust 2018 and requires a compiler version >= 1.40.
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See examples for usage.
 
 # Building
 
-As of 0.8.0 This crate uses Rust 2018 and requires a compiler version >= 1.40.0.
+As of 0.8.0 This crate uses Rust 2018 and requires a compiler version >= 1.43.1.
 
 ## Windows
 


### PR DESCRIPTION
- Determined MSRV to be 1.40.0 as of this writing. Closes #130 .
- Add separate `cargo build` step.  It's useful to see where build failed. 
- Run clippy only when `stable` compiler.