### PR TITLE
Build-time libpcap version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Updated dependency `futures` from version 0.1 to 0.3.
 - Feature `tokio` renamed to `capture-stream` because Cargo does not allow
   features and dependencies to have the same name.
+- `PCAP_LIBDIR` renamed to `LIBPCAP_LIBDIR` to distinguish the `pcap` crate
+  from the `libpcap` library.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `Derive(Clone)` to `Device` struct (#100).
+- Build-time `libpcap` version detection.
 
 ### Changed
 
@@ -14,6 +15,11 @@
 - Updated dependency `futures` from version 0.1 to 0.3.
 - Feature `tokio` renamed to `capture-stream` because Cargo does not allow
   features and dependencies to have the same name.
+
+### Removed
+
+- Feature flags `pcap-savefile-append`, `pcap-fopen-offline-precision`
+  (replaced by build-time `libpcap` version detection)
 
 ## [0.7.0] - 2017-08-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,22 +24,17 @@ futures = { version = "0.3", optional = true }
 tempdir = "0.3"
 tokio = { version = "0.2", features = ["rt-core"] }
 
+[build-dependencies]
+libloading = "0.6"
+regex = "1"
+
 [features]
-# This feature enables access to the function Capture::savefile_append.
-# This is disabled by default, because it depends on a relatively recent
-# version of libpcap (1.7.2).
-pcap-savefile-append = []
-
-# This feature enables access to the function Capture::from_raw_fd_with_precision.
-# This is disabled by default, because it requires libpcap >= 1.5.0.
-pcap-fopen-offline-precision = []
-
 # This feature enables access to the function Capture::stream.
 # This is disabled by default, because it depends on a tokio and mio
 capture-stream = ["mio", "tokio", "futures"]
 
 # A shortcut to enable all features.
-full = ["pcap-savefile-append", "pcap-fopen-offline-precision", "capture-stream"]
+full = ["capture-stream"]
 
 [lib]
 name = "pcap"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ libpcap should be installed on Mac OS X by default.
 
 If `PCAP_LIBDIR` environment variable is set when building the crate, it will be added to the linker search path - this allows linking against a specific `libpcap`.
 
+## Library Version
+
+The crate will automatically try to detect the installed `libpcap`/`wpcap` version by loading it during the build and calling `pcap_lib_version`. If for some reason this is not suitable, you can specify the desired library version by setting the environment variable `PCAP_VER` to the desired version. The version number is used to determine which library calls to include in the compilation.
+
+Th
+
 ## Optional Features
 
 #### `capture-stream`
@@ -53,29 +59,6 @@ This feature is supported only on ubuntu and macosx.
 ```toml
 [dependencies]
 pcap = { version = "0.7", features = ["capture-stream"] }
-```
-
-#### `pcap-savefile-append`
-
-To get access to the `Capture::savefile_append` function (which allows appending
-to an existing pcap file) you have to depend on the `pcap-savefile-append`
-feature flag. It requires at least libpcap version 1.7.2.
-
-```toml
-[dependencies]
-pcap = { version = "0.7", features = ["pcap-savefile-append"] }
-```
-
-#### `pcap-fopen-offline-precision`
-
-To enable `Capture::from_raw_fd_with_precision` constructor (which allows opening
-an offline capture from a raw file descriptor with a predefined timestamp precision)
-you have to add `pcap-fopen-offline-precision` feature flag. This requires libpcap
-version 1.5.0 or later.
-
-```toml
-[dependencies]
-pcap = { version = "0.7", features = ["pcap-fopen-offline-precision"] }
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -41,13 +41,11 @@ libpcap should be installed on Mac OS X by default.
 
 ## Library Location
 
-If `PCAP_LIBDIR` environment variable is set when building the crate, it will be added to the linker search path - this allows linking against a specific `libpcap`.
+If `LIBPCAP_LIBDIR` environment variable is set when building the crate, it will be added to the linker search path - this allows linking against a specific `libpcap`.
 
 ## Library Version
 
-The crate will automatically try to detect the installed `libpcap`/`wpcap` version by loading it during the build and calling `pcap_lib_version`. If for some reason this is not suitable, you can specify the desired library version by setting the environment variable `PCAP_VER` to the desired version. The version number is used to determine which library calls to include in the compilation.
-
-Th
+The crate will automatically try to detect the installed `libpcap`/`wpcap` version by loading it during the build and calling `pcap_lib_version`. If for some reason this is not suitable, you can specify the desired library version by setting the environment variable `LIBPCAP_VER` to the desired version (e.g. `env LIBPCAP_VER=1.5.0`). The version number is used to determine which library calls to include in the compilation.
 
 ## Optional Features
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,98 @@
 use std::env;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct Version {
+    major: usize,
+    minor: usize,
+    micro: usize,
+}
+
+impl Version {
+    fn new(major: usize, minor: usize, micro: usize) -> Version {
+        Version {
+            major,
+            minor,
+            micro,
+        }
+    }
+}
+
+fn get_pcap_lib_version() -> Result<Version, Box<dyn std::error::Error>> {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let libfile = "libpcap.so";
+    #[cfg(target_os = "macos")]
+    let libfile = "libpcap.dylib";
+    #[cfg(windows)]
+    let libfile = "wpcap.dll";
+
+    let lib = libloading::Library::new(libfile)?;
+
+    type PcapLibVersion = unsafe extern "C" fn() -> *mut c_char;
+    let pcap_lib_version = unsafe { lib.get::<PcapLibVersion>(b"pcap_lib_version")? };
+
+    let c_buf: *const c_char = unsafe { pcap_lib_version() };
+    let c_str: &CStr = unsafe { CStr::from_ptr(c_buf) };
+    let v_str: &str = c_str.to_str()?;
+
+    let err = format!("cannot infer pcap lib version from: {}", v_str);
+
+    #[cfg(not(windows))]
+    {
+        let re = regex::Regex::new(r"libpcap version ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)")?;
+        let captures = re.captures(v_str).ok_or(err.clone())?;
+
+        let major_str = captures.get(1).ok_or(err.clone())?.as_str();
+        let minor_str = captures.get(2).ok_or(err.clone())?.as_str();
+        let micro_str = captures.get(3).ok_or(err.clone())?.as_str();
+
+        Ok(Version::new(
+            major_str.parse::<usize>()?,
+            minor_str.parse::<usize>()?,
+            micro_str.parse::<usize>()?,
+        ))
+    }
+
+    #[cfg(windows)]
+    {
+        let re = regex::Regex::new(r"based on libpcap version ([[:digit:]]+)\.([[:digit:]]+)")?;
+        let captures = re.captures(v_str).ok_or(err.clone())?;
+
+        let major_str = captures.get(1).ok_or(err.clone())?.as_str();
+        let minor_str = captures.get(2).ok_or(err.clone())?.as_str();
+
+        Ok(Version::new(
+            major_str.parse::<usize>()?,
+            minor_str.parse::<usize>()?,
+            0,
+        ))
+    }
+}
+
+fn emit_cfg_flags(version: Version) {
+    assert!(
+        version >= Version::new(1, 0, 0),
+        "required pcap lib version: >=1.0.0"
+    );
+    let api_vers: Vec<Version> = vec![
+        Version::new(1, 2, 1),
+        Version::new(1, 5, 0),
+        Version::new(1, 7, 2),
+        Version::new(1, 9, 0),
+        Version::new(1, 9, 1),
+    ];
+
+    for v in api_vers.iter().filter(|&v| v <= &version) {
+        println!("cargo:rustc-cfg=pcap_{}_{}_{}", v.major, v.minor, v.micro);
+    }
+}
 
 fn main() {
     if let Ok(libdir) = env::var("PCAP_LIBDIR") {
         println!("cargo:rustc-link-search=native={}", libdir);
     }
+
+    let version = get_pcap_lib_version().unwrap();
+    emit_cfg_flags(version);
 }

--- a/build.rs
+++ b/build.rs
@@ -37,7 +37,7 @@ impl Version {
 }
 
 fn get_pcap_lib_version() -> Result<Version, Box<dyn std::error::Error>> {
-    if let Ok(libver) = env::var("PCAP_VER") {
+    if let Ok(libver) = env::var("LIBPCAP_VER") {
         return Version::parse(&libver);
     }
 
@@ -105,12 +105,12 @@ fn emit_cfg_flags(version: Version) {
     ];
 
     for v in api_vers.iter().filter(|&v| v <= &version) {
-        println!("cargo:rustc-cfg=pcap_{}_{}_{}", v.major, v.minor, v.micro);
+        println!("cargo:rustc-cfg=libpcap_{}_{}_{}", v.major, v.minor, v.micro);
     }
 }
 
 fn main() {
-    if let Ok(libdir) = env::var("PCAP_LIBDIR") {
+    if let Ok(libdir) = env::var("LIBPCAP_LIBDIR") {
         println!("cargo:rustc-link-search=native={}", libdir);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,6 +435,7 @@ impl Capture<Offline> {
 
     /// Opens an offline capture handle from a pcap dump file, given a path.
     /// Takes an additional precision argument specifying the time stamp precision desired.
+    #[cfg(pcap_1_5_0)]
     pub fn from_file_with_precision<P: AsRef<Path>>(path: P, precision: Precision) -> Result<Capture<Offline>, Error> {
         Capture::new_raw(path.as_ref().to_str(), |path, err| unsafe {
             raw::pcap_open_offline_with_tstamp_precision(path, precision as _, err)
@@ -452,7 +453,7 @@ impl Capture<Offline> {
 
     /// Opens an offline capture handle from a pcap dump file, given a file descriptor.
     /// Takes an additional precision argument specifying the time stamp precision desired.
-    #[cfg(all(not(windows), feature = "pcap-fopen-offline-precision"))]
+    #[cfg(pcap_1_5_0)]
     pub fn from_raw_fd_with_precision(fd: RawFd, precision: Precision) -> Result<Capture<Offline>, Error> {
         open_raw_fd(fd, b'r')
             .and_then(|file| Capture::new_raw(None, |_, err| unsafe {
@@ -524,7 +525,7 @@ impl Capture<Inactive> {
     }
 
     /// Set the time stamp type to be used by a capture device.
-    #[cfg(not(windows))]
+    #[cfg(pcap_1_2_1)]
     pub fn tstamp_type(self, tstamp_type: TimestampType) -> Capture<Inactive> {
         unsafe { raw::pcap_set_tstamp_type(*self.handle, tstamp_type as _) };
         self
@@ -552,7 +553,7 @@ impl Capture<Inactive> {
     }
 
     /// Set the time stamp precision returned in captures.
-    #[cfg(not(windows))]
+    #[cfg(pcap_1_5_0)]
     pub fn precision(self, precision: Precision) -> Capture<Inactive> {
         unsafe { raw::pcap_set_tstamp_precision(*self.handle, precision as _) };
         self
@@ -620,7 +621,7 @@ impl<T: Activated + ? Sized> Capture<T> {
     /// byte order as the host opening the file, and has the same time stamp precision,
     /// link-layer header type,  and  snapshot length as p, it will write new packets
     /// at the end of the file.
-    #[cfg(feature = "pcap-savefile-append")]
+    #[cfg(pcap_1_7_2)]
     pub fn savefile_append<P: AsRef<Path>>(&self, path: P) -> Result<Savefile, Error> {
         let name = CString::new(path.as_ref().to_str().unwrap())?;
         let handle = unsafe { raw::pcap_dump_open_append(*self.handle, name.as_ptr()) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,7 +435,7 @@ impl Capture<Offline> {
 
     /// Opens an offline capture handle from a pcap dump file, given a path.
     /// Takes an additional precision argument specifying the time stamp precision desired.
-    #[cfg(pcap_1_5_0)]
+    #[cfg(libpcap_1_5_0)]
     pub fn from_file_with_precision<P: AsRef<Path>>(path: P, precision: Precision) -> Result<Capture<Offline>, Error> {
         Capture::new_raw(path.as_ref().to_str(), |path, err| unsafe {
             raw::pcap_open_offline_with_tstamp_precision(path, precision as _, err)
@@ -453,7 +453,7 @@ impl Capture<Offline> {
 
     /// Opens an offline capture handle from a pcap dump file, given a file descriptor.
     /// Takes an additional precision argument specifying the time stamp precision desired.
-    #[cfg(pcap_1_5_0)]
+    #[cfg(libpcap_1_5_0)]
     pub fn from_raw_fd_with_precision(fd: RawFd, precision: Precision) -> Result<Capture<Offline>, Error> {
         open_raw_fd(fd, b'r')
             .and_then(|file| Capture::new_raw(None, |_, err| unsafe {
@@ -525,7 +525,7 @@ impl Capture<Inactive> {
     }
 
     /// Set the time stamp type to be used by a capture device.
-    #[cfg(pcap_1_2_1)]
+    #[cfg(libpcap_1_2_1)]
     pub fn tstamp_type(self, tstamp_type: TimestampType) -> Capture<Inactive> {
         unsafe { raw::pcap_set_tstamp_type(*self.handle, tstamp_type as _) };
         self
@@ -553,7 +553,7 @@ impl Capture<Inactive> {
     }
 
     /// Set the time stamp precision returned in captures.
-    #[cfg(pcap_1_5_0)]
+    #[cfg(libpcap_1_5_0)]
     pub fn precision(self, precision: Precision) -> Capture<Inactive> {
         unsafe { raw::pcap_set_tstamp_precision(*self.handle, precision as _) };
         self
@@ -621,7 +621,7 @@ impl<T: Activated + ? Sized> Capture<T> {
     /// byte order as the host opening the file, and has the same time stamp precision,
     /// link-layer header type,  and  snapshot length as p, it will write new packets
     /// at the end of the file.
-    #[cfg(pcap_1_7_2)]
+    #[cfg(libpcap_1_7_2)]
     pub fn savefile_append<P: AsRef<Path>>(&self, path: P) -> Result<Savefile, Error> {
         let name = CString::new(path.as_ref().to_str().unwrap())?;
         let handle = unsafe { raw::pcap_dump_open_append(*self.handle, name.as_ptr()) };

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -153,7 +153,7 @@ extern "C" {
     pub fn pcap_get_selectable_fd(arg1: *mut pcap_t) -> c_int;
 }
 
-#[cfg(pcap_1_2_1)]
+#[cfg(libpcap_1_2_1)]
 extern "C" {
     // pub fn pcap_free_tstamp_types(arg1: *mut c_int) -> ();
     // pub fn pcap_list_tstamp_types(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int;
@@ -163,7 +163,7 @@ extern "C" {
     // pub fn pcap_tstamp_type_val_to_name(arg1: c_int) -> *const c_char;
 }
 
-#[cfg(pcap_1_5_0)]
+#[cfg(libpcap_1_5_0)]
 extern "C" {
     pub fn pcap_fopen_offline_with_tstamp_precision(arg1: *mut FILE, arg2: c_uint,
                                                     arg3: *mut c_char) -> *mut pcap_t;
@@ -176,12 +176,12 @@ extern "C" {
     pub fn pcap_set_tstamp_precision(arg1: *mut pcap_t, arg2: c_int) -> c_int;
 }
 
-#[cfg(pcap_1_7_2)]
+#[cfg(libpcap_1_7_2)]
 extern "C" {
     pub fn pcap_dump_open_append(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t;
 }
 
-#[cfg(pcap_1_9_0)]
+#[cfg(libpcap_1_9_0)]
 extern "C" {
     // pcap_bufsize
     // pcap_createsrcstr
@@ -198,7 +198,7 @@ extern "C" {
     // pcap_setsampling
 }
 
-#[cfg(pcap_1_9_1)]
+#[cfg(libpcap_1_9_1)]
 extern "C" {
     // pcap_datalink_val_to_description_or_dlt
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -91,30 +91,12 @@ extern "C" {
     pub fn pcap_set_promisc(arg1: *mut pcap_t, arg2: c_int) -> c_int;
     // pub fn pcap_can_set_rfmon(arg1: *mut pcap_t) -> c_int;
     pub fn pcap_set_timeout(arg1: *mut pcap_t, arg2: c_int) -> c_int;
-    #[cfg(not(windows))]
-    pub fn pcap_set_tstamp_type(arg1: *mut pcap_t, arg2: c_int) -> c_int;
-    // pub fn pcap_set_immediate_mode(arg1: *mut pcap_t, arg2: c_int) -> c_int;
     pub fn pcap_set_buffer_size(arg1: *mut pcap_t, arg2: c_int) -> c_int;
-    #[cfg(not(windows))]
-    pub fn pcap_set_tstamp_precision(arg1: *mut pcap_t, arg2: c_int) -> c_int;
-    // pub fn pcap_get_tstamp_precision(arg1: *mut pcap_t) -> c_int;
     pub fn pcap_activate(arg1: *mut pcap_t) -> c_int;
-    // pub fn pcap_list_tstamp_types(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int;
-    // pub fn pcap_free_tstamp_types(arg1: *mut c_int);
-    // pub fn pcap_tstamp_type_name_to_val(arg1: *const c_char) -> c_int;
-    // pub fn pcap_tstamp_type_val_to_name(arg1: c_int) -> *const c_char;
-    // pub fn pcap_tstamp_type_val_to_description(arg1: c_int) -> *const c_char;
     // pub fn pcap_open_live(arg1: *const c_char, arg2: c_int, arg3: c_int, arg4: c_int,
     //                       arg5: *mut c_char) -> *mut pcap_t;
     pub fn pcap_open_dead(arg1: c_int, arg2: c_int) -> *mut pcap_t;
-    pub fn pcap_open_dead_with_tstamp_precision(arg1: c_int, arg2: c_int,
-                                                 arg3: c_uint) -> *mut pcap_t;
-    pub fn pcap_open_offline_with_tstamp_precision(arg1: *const c_char, arg2: c_uint,
-                                                   arg3: *mut c_char) -> *mut pcap_t;
     pub fn pcap_open_offline(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t;
-    #[cfg(feature = "pcap-fopen-offline-precision")]
-    pub fn pcap_fopen_offline_with_tstamp_precision(arg1: *mut FILE, arg2: c_uint,
-                                                    arg3: *mut c_char) -> *mut pcap_t;
     pub fn pcap_fopen_offline(arg1: *mut FILE, arg2: *mut c_char) -> *mut pcap_t;
     pub fn pcap_close(arg1: *mut pcap_t);
     // pub fn pcap_loop(arg1: *mut pcap_t, arg2: c_int,
@@ -158,8 +140,6 @@ extern "C" {
     pub fn pcap_fileno(arg1: *mut pcap_t) -> c_int;
     pub fn pcap_dump_open(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t;
     pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE) -> *mut pcap_dumper_t;
-    #[cfg(feature = "pcap-savefile-append")]
-    pub fn pcap_dump_open_append(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t;
     // pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut FILE;
     // pub fn pcap_dump_ftell(arg1: *mut pcap_dumper_t) -> c_long;
     // pub fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> c_int;
@@ -171,6 +151,56 @@ extern "C" {
     // pub fn bpf_image(arg1: *const bpf_insn, arg2: c_int) -> *mut c_char;
     // pub fn bpf_dump(arg1: *const bpf_program, arg2: c_int);
     pub fn pcap_get_selectable_fd(arg1: *mut pcap_t) -> c_int;
+}
+
+#[cfg(pcap_1_2_1)]
+extern "C" {
+    // pub fn pcap_free_tstamp_types(arg1: *mut c_int) -> ();
+    // pub fn pcap_list_tstamp_types(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int;
+    pub fn pcap_set_tstamp_type(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+    // pub fn pcap_tstamp_type_name_to_val(arg1: *const c_char) -> c_int;
+    // pub fn pcap_tstamp_type_val_to_description(arg1: c_int) -> *const c_char;
+    // pub fn pcap_tstamp_type_val_to_name(arg1: c_int) -> *const c_char;
+}
+
+#[cfg(pcap_1_5_0)]
+extern "C" {
+    pub fn pcap_fopen_offline_with_tstamp_precision(arg1: *mut FILE, arg2: c_uint,
+                                                    arg3: *mut c_char) -> *mut pcap_t;
+    // pub fn pcap_get_tstamp_precision(arg1: *mut pcap_t) -> c_int;
+    pub fn pcap_open_dead_with_tstamp_precision(arg1: c_int, arg2: c_int,
+                                                arg3: c_uint) -> *mut pcap_t;
+    pub fn pcap_open_offline_with_tstamp_precision(arg1: *const c_char, arg2: c_uint,
+                                                   arg3: *mut c_char) -> *mut pcap_t;
+    // pub fn pcap_set_immediate_mode(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+    pub fn pcap_set_tstamp_precision(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+}
+
+#[cfg(pcap_1_7_2)]
+extern "C" {
+    pub fn pcap_dump_open_append(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t;
+}
+
+#[cfg(pcap_1_9_0)]
+extern "C" {
+    // pcap_bufsize
+    // pcap_createsrcstr
+    // pcap_dump_ftell64
+    // pcap_findalldevs_ex
+    // pcap_get_required_select_timeout
+    // pcap_open
+    // pcap_parsesrcstr
+    // pcap_remoteact_accept
+    // pcap_remoteact_cleanup
+    // pcap_remoteact_close
+    // pcap_remoteact_list
+    // pcap_set_protocol_linux
+    // pcap_setsampling
+}
+
+#[cfg(pcap_1_9_1)]
+extern "C" {
+    // pcap_datalink_val_to_description_or_dlt
 }
 
 #[cfg(windows)]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -135,7 +135,7 @@ fn capture_dead_savefile() {
 }
 
 #[test]
-#[cfg(feature = "pcap-savefile-append")]
+#[cfg(pcap_1_7_2)]
 fn capture_dead_savefile_append() {
     let mut packets1 = Packets::new();
     packets1.push(1460408319, 1234, 1, 1, &[1]);
@@ -194,7 +194,7 @@ fn test_raw_fd_api() {
 
     assert_eq!(Capture::from_raw_fd(-999).err().unwrap(),
                Error::InvalidRawFd);
-    #[cfg(feature = "pcap-fopen-offline-precision")]
+    #[cfg(pcap_1_5_0)]
     {
         assert_eq!(Capture::from_raw_fd_with_precision(-999, Precision::Micro).err().unwrap(),
                    Error::InvalidRawFd);
@@ -231,12 +231,12 @@ fn test_raw_fd_api() {
     File::open(&filename).unwrap().read_to_end(&mut v2).unwrap();
     assert_eq!(v1, v2);
 
-    #[cfg(feature = "pcap-fopen-offline-precision")]
+    #[cfg(pcap_1_5_0)]
     fn from_raw_fd_with_precision(fd: RawFd, precision: Precision) -> Capture<Offline> {
         Capture::from_raw_fd_with_precision(fd, precision).unwrap()
     }
 
-    #[cfg(not(feature = "pcap-fopen-offline-precision"))]
+    #[cfg(not(pcap_1_5_0))]
     fn from_raw_fd_with_precision(fd: RawFd, _: Precision) -> Capture<Offline> {
         Capture::from_raw_fd(fd).unwrap()
     }


### PR DESCRIPTION
This pull requests replaces the previously existing per-API call features with build-time detection of libpcap version. There is also the option to specify the desired version using the `PCAP_VER` optional environment variable (the default is to use the version of the installed library).

Currently marked as a draft PR as I am not sure how to handle WinPcap. In #118 we discussed what the minimal supported libpcap version should be and 1.5.3 emerged as a possible candidate (supported on Centos 7 until 2024). Therefore, it would be ideal if I could also remove the `1_2_1` and `1_5_0` flags. However, I kept them around as the way WinPcap is currently handled is that it's treated as libpcap 1.0.0 with a few specific calls. I also don't know what npcap does at all for a version.

Questions for @sekineh:
- should we just keep handling WinPcap as a 1.0.0 library with some extra calls?
- can npcap be handled as a libpcap library version 1.9 (or whatever else it is)?
- or would it just be easiest to have a `wpcap` and `npcap` flags?

My proposal is:
- in `raw.rs` have a set of core functions that all of winpcap, npcap, and libpcap on linux share
- a config flag of the form `pcap_X_Y_Z` means that any of the three above that claim to support version X.Y.Z should work with this flag
- within a version we might have to split further between winpcap, npcap, and libpcap. For example in #136 it is pointed out that npcap has `hopen` instead of `fopen` so we would have:
```rust
#[cfg(pcap_1_5_0)]
extern "C" {
    #[cfg(not(windows))]
    { 
        pub fn pcap_fopen_offline_with_tstamp_precision(/* unix args */) -> *mut pcap_t;
    }
    
    #[cfg(npcap)]
    {
        pub fn pcap_hopen_offline_with_tstamp_precision(/* npcap args */) -> *mut pcap_t;
    }
 }
```

What do you think?

Closes #118, #136 