### PR TITLE
Add rerun-if-env-changed to build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -110,6 +110,9 @@ fn emit_cfg_flags(version: Version) {
 }
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=LIBPCAP_LIBDIR");
+    println!("cargo:rerun-if-env-changed=LIBPCAP_VER");
+
     if let Ok(libdir) = env::var("LIBPCAP_LIBDIR") {
         println!("cargo:rustc-link-search=native={}", libdir);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,7 +605,7 @@ impl<T: Activated + ? Sized> Capture<T> {
 
     /// Create a `Savefile` context for recording captured packets using this `Capture`'s
     /// configurations. The output is written to a raw file descriptor which is opened
-    // in `"w"` mode.
+    /// in `"w"` mode.
     #[cfg(not(windows))]
     pub fn savefile_raw_fd(&self, fd: RawFd) -> Result<Savefile, Error> {
         open_raw_fd(fd, b'w')


### PR DESCRIPTION
If either of the `LIBPCAP` environment variables we use in `build.rs` changes, cargo will recompile