### PR TITLE
Add support for immediate mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `Derive(Clone)` to `Device` struct (#100).
 - Build-time `libpcap` version detection.
+- Add support for immediate mode.
 
 ### Changed
 

--- a/examples/easylisten.rs
+++ b/examples/easylisten.rs
@@ -1,6 +1,14 @@
 fn main() {
     // get the default Device
-    let mut cap = pcap::Device::lookup().unwrap().open().unwrap();
+    let device = pcap::Device::lookup().unwrap();
+    println!("Using device {}", device.name);
+
+    // Setup Capture
+    let mut cap = pcap::Capture::from_device(device)
+        .unwrap()
+        .immediate_mode(true)
+        .open()
+        .unwrap();
 
     // get a packet and print its bytes
     println!("{:?}", cap.next());

--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -4,7 +4,11 @@ fn main() {
         println!("Found device! {:?}", device);
 
         // now you can create a Capture with this Device if you want.
-        let mut cap = device.open().unwrap();
+        let mut cap = pcap::Capture::from_device(device)
+            .unwrap()
+            .immediate_mode(true)
+            .open()
+            .unwrap();
 
         // get a packet from this capture
         let packet = cap.next();

--- a/examples/getstatistics.rs
+++ b/examples/getstatistics.rs
@@ -1,11 +1,22 @@
 fn main() {
     // get the default Device
-    let mut cap = pcap::Device::lookup().unwrap().open().unwrap();
+    let device = pcap::Device::lookup().unwrap();
+    println!("Using device {}", device.name);
+
+    // Setup Capture
+    let mut cap = pcap::Capture::from_device(device)
+        .unwrap()
+        .immediate_mode(true)
+        .open()
+        .unwrap();
 
     // get 10 packets
     for _ in 0..10 {
-      cap.next().ok();
+        cap.next().ok();
     }
     let stats = cap.stats().unwrap();
-    println!("Received: {}, dropped: {}, if_dropped: {}", stats.received, stats.dropped, stats.if_dropped);
+    println!(
+        "Received: {}, dropped: {}, if_dropped: {}",
+        stats.received, stats.dropped, stats.if_dropped
+    );
 }

--- a/examples/listenlocalhost.rs
+++ b/examples/listenlocalhost.rs
@@ -1,12 +1,16 @@
 fn main() {
     // listen on the device named "any", which is only available on Linux. This is only for
     // demonstration purposes.
-    let mut cap = pcap::Capture::from_device("any").unwrap().open().unwrap();
+    let mut cap = pcap::Capture::from_device("any")
+        .unwrap()
+        .immediate_mode(true)
+        .open()
+        .unwrap();
 
     // filter out all packets that don't have 127.0.0.1 as a source or destination.
     cap.filter("host 127.0.0.1").unwrap();
 
     while let Ok(packet) = cap.next() {
-    	println!("got packet! {:?}", packet);
+        println!("got packet! {:?}", packet);
     }
 }

--- a/examples/savefile.rs
+++ b/examples/savefile.rs
@@ -1,29 +1,37 @@
 use pcap::*;
 
 fn main() {
-	{
-		// open capture from default device
-		let mut cap = Capture::from_device(Device::lookup().unwrap()).unwrap().open().unwrap();
+    {
+        // open capture from default device
+        let device = Device::lookup().unwrap();
+        println!("Using device {}", device.name);
 
-		// open savefile using the capture
-		let mut savefile = cap.savefile("test.pcap").unwrap();
+        // Setup Capture
+        let mut cap = Capture::from_device(device)
+            .unwrap()
+            .immediate_mode(true)
+            .open()
+            .unwrap();
 
-		// get a packet from the interface
-		let p = cap.next().unwrap();
+        // open savefile using the capture
+        let mut savefile = cap.savefile("test.pcap").unwrap();
 
-		// print the packet out
-		println!("packet received on network: {:?}", p);
+        // get a packet from the interface
+        let p = cap.next().unwrap();
 
-		// write the packet to the savefile
-		savefile.write(&p);
-	}
+        // print the packet out
+        println!("packet received on network: {:?}", p);
 
-	// open a new capture from the test.pcap file we wrote to above
-	let mut cap = Capture::from_file("test.pcap").unwrap();
+        // write the packet to the savefile
+        savefile.write(&p);
+    }
 
-	// get a packet
-	let p = cap.next().unwrap();
+    // open a new capture from the test.pcap file we wrote to above
+    let mut cap = Capture::from_file("test.pcap").unwrap();
 
-	// print that packet out -- it should be the same as the one we printed above
-	println!("packet obtained from file: {:?}", p);
+    // get a packet
+    let p = cap.next().unwrap();
+
+    // print that packet out -- it should be the same as the one we printed above
+    println!("packet obtained from file: {:?}", p);
 }

--- a/examples/streamlisten.rs
+++ b/examples/streamlisten.rs
@@ -13,7 +13,11 @@ impl PacketCodec for SimpleDumpCodec {
 }
 
 fn new_stream() -> Result<PacketStream<Active, SimpleDumpCodec>, Error> {
-    let cap = Capture::from_device(Device::lookup()?)?
+    // get the default Device
+    let device = Device::lookup()?;
+    println!("Using device {}", device.name);
+
+    let cap = Capture::from_device(device)?
         .immediate_mode(true)
         .open()?
         .setnonblock()?;

--- a/examples/streamlisten.rs
+++ b/examples/streamlisten.rs
@@ -14,6 +14,7 @@ impl PacketCodec for SimpleDumpCodec {
 
 fn new_stream() -> Result<PacketStream<Active, SimpleDumpCodec>, Error> {
     let cap = Capture::from_device(Device::lookup()?)?
+        .immediate_mode(true)
         .open()?
         .setnonblock()?;
     cap.stream(SimpleDumpCodec {})

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -205,7 +205,7 @@ extern "C" {
 
 #[cfg(windows)]
 #[link(name = "wpcap")]
-const WINPCAP_MINTOCOPY_DEFAULT: i32 = 16000;
+pub const WINPCAP_MINTOCOPY_DEFAULT: c_int = 16000;
 
 #[cfg(windows)]
 #[link(name = "wpcap")]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -172,7 +172,7 @@ extern "C" {
                                                 arg3: c_uint) -> *mut pcap_t;
     pub fn pcap_open_offline_with_tstamp_precision(arg1: *const c_char, arg2: c_uint,
                                                    arg3: *mut c_char) -> *mut pcap_t;
-    // pub fn pcap_set_immediate_mode(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+    pub fn pcap_set_immediate_mode(arg1: *mut pcap_t, arg2: c_int) -> c_int;
     pub fn pcap_set_tstamp_precision(arg1: *mut pcap_t, arg2: c_int) -> c_int;
 }
 
@@ -205,7 +205,13 @@ extern "C" {
 
 #[cfg(windows)]
 #[link(name = "wpcap")]
-extern "C" {}
+const WINPCAP_MINTOCOPY_DEFAULT: i32 = 16000;
+
+#[cfg(windows)]
+#[link(name = "wpcap")]
+extern "C" {
+    pub fn pcap_setmintocopy(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+}
 
 #[cfg(not(windows))]
 #[link(name = "pcap")]


### PR DESCRIPTION
The only complicated part of this change is how to support on WinPcap as WinPcap provides a separate API call `pcap_setmintocopy` which is used to set immediate mode. However, it does mean that the user can unset/set immediate mode by calling `min_to_copy` instead (possibly by accident).

Other options are:
* Not provide `min_to_copy` in `pcap`. However, since we must already provide `pcap_setmintocopy` in `raw.rs` then I see no reason not to.
* Make Windows user libraries use `min_to_copy` to set immediate mode and exclude the `immediate_mode` function from windows builds. I don't like this solution as this forces programmers to worry about windows vs linux/mac themselves.

Closes #45 
Should fix #93 