### PR TITLE
Make all methods for constructing objects out of RawFd or raw pointers unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - `PCAP_LIBDIR` renamed to `LIBPCAP_LIBDIR` to distinguish the `pcap` crate
   from the `libpcap` library.
 - All methods that construct objects out of a `RawFd` are now unsafe.
+- All methods that take a raw pointer are now unsafe. Some of these functions
+  were renamed from `new` to `from_handle` to underline this.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   features and dependencies to have the same name.
 - `PCAP_LIBDIR` renamed to `LIBPCAP_LIBDIR` to distinguish the `pcap` crate
   from the `libpcap` library.
+- All methods that construct objects out of a `RawFd` are now unsafe.
 
 ### Removed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,8 +452,11 @@ impl Capture<Offline> {
         })
     }
 
-    /// Opens an offline capture handle from a pcap dump file, given a file descriptor. Unsafe,
-    /// because the returned Capture assumes it is the sole owner of the file descriptor.
+    /// Opens an offline capture handle from a pcap dump file, given a file descriptor.
+    ///
+    /// # Safety
+    ///
+    /// Unsafe, because the returned Capture assumes it is the sole owner of the file descriptor.
     #[cfg(not(windows))]
     pub unsafe fn from_raw_fd(fd: RawFd) -> Result<Capture<Offline>, Error> {
         open_raw_fd(fd, b'r')
@@ -463,8 +466,11 @@ impl Capture<Offline> {
     }
 
     /// Opens an offline capture handle from a pcap dump file, given a file descriptor. Takes an
-    /// additional precision argument specifying the time stamp precision desired. Unsafe, because
-    /// the returned Capture assumes it is the sole owner of the file descriptor.
+    /// additional precision argument specifying the time stamp precision desired.
+    ///
+    /// # Safety
+    ///
+    /// Unsafe, because the returned Capture assumes it is the sole owner of the file descriptor.
     #[cfg(all(not(windows), libpcap_1_5_0))]
     pub unsafe fn from_raw_fd_with_precision(fd: RawFd, precision: Precision) -> Result<Capture<Offline>, Error> {
         open_raw_fd(fd, b'r')
@@ -640,8 +646,11 @@ impl<T: Activated + ? Sized> Capture<T> {
 
     /// Create a `Savefile` context for recording captured packets using this `Capture`'s
     /// configurations. The output is written to a raw file descriptor which is opened in `"w"`
-    /// mode. Unsafe, because the returned Savefile assumes it is the sole owner of the file
-    /// descriptor.
+    /// mode.
+    ///
+    /// # Safety
+    ///
+    /// Unsafe, because the returned Savefile assumes it is the sole owner of the file descriptor.
     #[cfg(not(windows))]
     pub unsafe fn savefile_raw_fd(&self, fd: RawFd) -> Result<Savefile, Error> {
         open_raw_fd(fd, b'w')
@@ -843,6 +852,8 @@ impl Drop for Savefile {
 }
 
 #[cfg(not(windows))]
+/// # Safety
+///
 /// Unsafe, because the returned FILE assumes it is the sole owner of the file descriptor.
 pub unsafe fn open_raw_fd(fd: RawFd, mode: u8) -> Result<*mut libc::FILE, Error> {
     let mode = vec![mode, 0];


### PR DESCRIPTION
As per #127, constructing objects out of a RawFd is unsafe as the objects assume they are the sole owner of the file descriptor. This mimics the design of the [`FromRawFd`](https://doc.rust-lang.org/std/os/unix/io/trait.FromRawFd.html) trait. However, I decided not to implement that trait because
- we have more functions than just `from_raw_fd`
- we return a `Result` not `Self` - I figure it was preferable to keep the interface contract

If the trait is preferable in the future, we can think about it.

Closes #127.