### PR TITLE
Clippy lints for build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,11 +22,11 @@ impl Version {
         let err = format!("invalid pcap lib version: {}", s);
 
         let re = regex::Regex::new(r"([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)")?;
-        let captures = re.captures(s).ok_or(err.clone())?;
+        let captures = re.captures(s).ok_or_else(|| err.clone())?;
 
-        let major_str = captures.get(1).ok_or(err.clone())?.as_str();
-        let minor_str = captures.get(2).ok_or(err.clone())?.as_str();
-        let micro_str = captures.get(3).ok_or(err.clone())?.as_str();
+        let major_str = captures.get(1).ok_or_else(|| err.clone())?.as_str();
+        let minor_str = captures.get(2).ok_or_else(|| err.clone())?.as_str();
+        let micro_str = captures.get(3).ok_or_else(|| err.clone())?.as_str();
 
         Ok(Version::new(
             major_str.parse::<usize>()?,
@@ -62,11 +62,11 @@ fn get_pcap_lib_version() -> Result<Version, Box<dyn std::error::Error>> {
     #[cfg(not(windows))]
     {
         let re = regex::Regex::new(r"libpcap version ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)")?;
-        let captures = re.captures(v_str).ok_or(err.clone())?;
+        let captures = re.captures(v_str).ok_or_else(|| err.clone())?;
 
-        let major_str = captures.get(1).ok_or(err.clone())?.as_str();
-        let minor_str = captures.get(2).ok_or(err.clone())?.as_str();
-        let micro_str = captures.get(3).ok_or(err.clone())?.as_str();
+        let major_str = captures.get(1).ok_or_else(|| err.clone())?.as_str();
+        let minor_str = captures.get(2).ok_or_else(|| err.clone())?.as_str();
+        let micro_str = captures.get(3).ok_or_else(|| err.clone())?.as_str();
 
         Ok(Version::new(
             major_str.parse::<usize>()?,


### PR DESCRIPTION
Bunch of clippy lints that do not appear if you `cargo build` first before running `cargo clippy`.