### PR TITLE
Add rustfmt to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
-          components: clippy
+          components: clippy, rustfmt
           override: true
       - name: cargo build
         run: cargo build ${{ matrix.profile }} ${{ matrix.features }}
@@ -63,3 +63,6 @@ jobs:
         run: cargo clippy ${{ matrix.profile }} ${{ matrix.features }} -- -D warnings
       - name: cargo doc
         run: cargo doc ${{ matrix.profile }} ${{ matrix.features }}
+      - name: cargo fmt
+        if: matrix.toolchain == 'stable'
+        run: cargo fmt -- --check

--- a/build.rs
+++ b/build.rs
@@ -61,7 +61,8 @@ fn get_pcap_lib_version() -> Result<Version, Box<dyn std::error::Error>> {
 
     #[cfg(not(windows))]
     {
-        let re = regex::Regex::new(r"libpcap version ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)")?;
+        let re =
+            regex::Regex::new(r"libpcap version ([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)")?;
         let captures = re.captures(v_str).ok_or_else(|| err.clone())?;
 
         let major_str = captures.get(1).ok_or_else(|| err.clone())?.as_str();
@@ -105,7 +106,10 @@ fn emit_cfg_flags(version: Version) {
     ];
 
     for v in api_vers.iter().filter(|&v| v <= &version) {
-        println!("cargo:rustc-cfg=libpcap_{}_{}_{}", v.major, v.minor, v.micro);
+        println!(
+            "cargo:rustc-cfg=libpcap_{}_{}_{}",
+            v.major, v.minor, v.micro
+        );
     }
 }
 

--- a/examples/nfbpfcompile.rs
+++ b/examples/nfbpfcompile.rs
@@ -2,8 +2,7 @@
 ///! it compiles a pcap expression in to a BPF filter, then serializes it using
 ///! a simple, safe encoding.
 ///!
-
-use pcap::{Capture, Linktype, BpfProgram};
+use pcap::{BpfProgram, Capture, Linktype};
 
 use std::env;
 use std::process;
@@ -29,7 +28,7 @@ fn main() {
         Err(_) => {
             println!("Invalid linklayer type {}", layertype);
             process::exit(1);
-        },
+        }
     };
 
     let capture = Capture::dead(lt).unwrap();
@@ -41,7 +40,8 @@ fn main() {
         }
     };
     let instructions = program.get_instructions();
-    let def: String = instructions.iter()
+    let def: String = instructions
+        .iter()
         .map(|ref op| format!("{}", op))
         .collect::<Vec<_>>()
         .join(",");

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -166,10 +166,10 @@ extern "C" {
 extern "C" {
     // pub fn pcap_free_tstamp_types(arg1: *mut c_int) -> ();
     // pub fn pcap_list_tstamp_types(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int;
+    // pub fn pcap_tstamp_type_name_to_val(arg1: *const c_char) -> c_int;
+    // pub fn pcap_tstamp_type_val_to_description(arg1: c_int) -> *const c_char;
+    // pub fn pcap_tstamp_type_val_to_name(arg1: c_int) -> *const c_char;
     pub fn pcap_set_tstamp_type(arg1: *mut pcap_t, arg2: c_int) -> c_int;
-// pub fn pcap_tstamp_type_name_to_val(arg1: *const c_char) -> c_int;
-// pub fn pcap_tstamp_type_val_to_description(arg1: c_int) -> *const c_char;
-// pub fn pcap_tstamp_type_val_to_name(arg1: c_int) -> *const c_char;
 }
 
 #[cfg(libpcap_1_5_0)]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
-use libc::{c_int, c_uint, c_char, c_uchar, c_ushort, sockaddr, timeval, FILE};
+use libc::{c_char, c_int, c_uchar, c_uint, c_ushort, sockaddr, timeval, FILE};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -19,9 +19,9 @@ pub struct bpf_insn {
     pub k: c_uint,
 }
 
-pub enum pcap_t { }
+pub enum pcap_t {}
 
-pub enum pcap_dumper_t { }
+pub enum pcap_dumper_t {}
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -77,10 +77,8 @@ pub struct pcap_addr_t {
     pub dstaddr: *mut sockaddr,
 }
 
-pub type pcap_handler = Option<extern "C" fn(arg1: *mut c_uchar,
-                                             arg2: *const pcap_pkthdr,
-                                             arg3: *const c_uchar)
-                                             -> ()>;
+pub type pcap_handler =
+    Option<extern "C" fn(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar) -> ()>;
 
 extern "C" {
     pub fn pcap_lookupdev(arg1: *mut c_char) -> *mut c_char;
@@ -104,8 +102,11 @@ extern "C" {
     // pub fn pcap_dispatch(arg1: *mut pcap_t, arg2: c_int, arg3: pcap_handler,
     //                      arg4: *mut c_uchar)-> c_int;
     // pub fn pcap_next(arg1: *mut pcap_t, arg2: *mut pcap_pkthdr) -> *const c_uchar;
-    pub fn pcap_next_ex(arg1: *mut pcap_t, arg2: *mut *mut pcap_pkthdr,
-                        arg3: *mut *const c_uchar) -> c_int;
+    pub fn pcap_next_ex(
+        arg1: *mut pcap_t,
+        arg2: *mut *mut pcap_pkthdr,
+        arg3: *mut *const c_uchar,
+    ) -> c_int;
     // pub fn pcap_breakloop(arg1: *mut pcap_t);
     pub fn pcap_stats(arg1: *mut pcap_t, arg2: *mut pcap_stat) -> c_int;
     pub fn pcap_setfilter(arg1: *mut pcap_t, arg2: *mut bpf_program) -> c_int;
@@ -117,13 +118,21 @@ extern "C" {
     // pub fn pcap_strerror(arg1: c_int) -> *const c_char;
     pub fn pcap_geterr(arg1: *mut pcap_t) -> *mut c_char;
     // pub fn pcap_perror(arg1: *mut pcap_t, arg2: *mut c_char);
-    pub fn pcap_compile(arg1: *mut pcap_t, arg2: *mut bpf_program, arg3: *const c_char,
-                        arg4: c_int, arg5: c_uint) -> c_int;
+    pub fn pcap_compile(
+        arg1: *mut pcap_t,
+        arg2: *mut bpf_program,
+        arg3: *const c_char,
+        arg4: c_int,
+        arg5: c_uint,
+    ) -> c_int;
     // pub fn pcap_compile_nopcap(arg1: c_int, arg2: c_int, arg3: *mut bpf_program,
     //                            arg4: *const c_char, arg5: c_int, arg6: c_uint) -> c_int;
     pub fn pcap_freecode(arg1: *mut bpf_program);
-    pub fn pcap_offline_filter(arg1: *const bpf_program, arg2: *const pcap_pkthdr,
-                               arg3: *const c_uchar) -> c_int;
+    pub fn pcap_offline_filter(
+        arg1: *const bpf_program,
+        arg2: *const pcap_pkthdr,
+        arg3: *const c_uchar,
+    ) -> c_int;
     pub fn pcap_datalink(arg1: *mut pcap_t) -> c_int;
     // pub fn pcap_datalink_ext(arg1: *mut pcap_t) -> c_int;
     pub fn pcap_list_datalinks(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int;
@@ -158,20 +167,29 @@ extern "C" {
     // pub fn pcap_free_tstamp_types(arg1: *mut c_int) -> ();
     // pub fn pcap_list_tstamp_types(arg1: *mut pcap_t, arg2: *mut *mut c_int) -> c_int;
     pub fn pcap_set_tstamp_type(arg1: *mut pcap_t, arg2: c_int) -> c_int;
-    // pub fn pcap_tstamp_type_name_to_val(arg1: *const c_char) -> c_int;
-    // pub fn pcap_tstamp_type_val_to_description(arg1: c_int) -> *const c_char;
-    // pub fn pcap_tstamp_type_val_to_name(arg1: c_int) -> *const c_char;
+// pub fn pcap_tstamp_type_name_to_val(arg1: *const c_char) -> c_int;
+// pub fn pcap_tstamp_type_val_to_description(arg1: c_int) -> *const c_char;
+// pub fn pcap_tstamp_type_val_to_name(arg1: c_int) -> *const c_char;
 }
 
 #[cfg(libpcap_1_5_0)]
 extern "C" {
-    pub fn pcap_fopen_offline_with_tstamp_precision(arg1: *mut FILE, arg2: c_uint,
-                                                    arg3: *mut c_char) -> *mut pcap_t;
+    pub fn pcap_fopen_offline_with_tstamp_precision(
+        arg1: *mut FILE,
+        arg2: c_uint,
+        arg3: *mut c_char,
+    ) -> *mut pcap_t;
     // pub fn pcap_get_tstamp_precision(arg1: *mut pcap_t) -> c_int;
-    pub fn pcap_open_dead_with_tstamp_precision(arg1: c_int, arg2: c_int,
-                                                arg3: c_uint) -> *mut pcap_t;
-    pub fn pcap_open_offline_with_tstamp_precision(arg1: *const c_char, arg2: c_uint,
-                                                   arg3: *mut c_char) -> *mut pcap_t;
+    pub fn pcap_open_dead_with_tstamp_precision(
+        arg1: c_int,
+        arg2: c_int,
+        arg3: c_uint,
+    ) -> *mut pcap_t;
+    pub fn pcap_open_offline_with_tstamp_precision(
+        arg1: *const c_char,
+        arg2: c_uint,
+        arg3: *mut c_char,
+    ) -> *mut pcap_t;
     pub fn pcap_set_immediate_mode(arg1: *mut pcap_t, arg2: c_int) -> c_int;
     pub fn pcap_set_tstamp_precision(arg1: *mut pcap_t, arg2: c_int) -> c_int;
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,31 +1,39 @@
-use mio::{Ready, Poll, PollOpt, Token};
+use super::Activated;
+use super::Capture;
+use super::Error;
+use super::Packet;
+use super::State;
 use mio::event::Evented;
 use mio::unix::EventedFd;
+use mio::{Poll, PollOpt, Ready, Token};
 use std::io;
 use std::marker::Unpin;
 #[cfg(not(windows))]
 use std::os::unix::io::RawFd;
 use std::pin::Pin;
-use super::Activated;
-use super::Packet;
-use super::Error;
-use super::State;
-use super::Capture;
 
 pub struct SelectableFd {
-    fd: RawFd
+    fd: RawFd,
 }
 
 impl Evented for SelectableFd {
-    fn register(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
-                -> io::Result<()>
-    {
+    fn register(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
         EventedFd(&self.fd).register(poll, token, interest, opts)
     }
 
-    fn reregister(&self, poll: &Poll, token: Token, interest: Ready, opts: PollOpt)
-                  -> io::Result<()>
-    {
+    fn reregister(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
         EventedFd(&self.fd).reregister(poll, token, interest, opts)
     }
 
@@ -39,21 +47,30 @@ pub trait PacketCodec {
     fn decode<'a>(&mut self, packet: Packet<'a>) -> Result<Self::Type, Error>;
 }
 
-pub struct PacketStream<T: State + ? Sized, C> {
+pub struct PacketStream<T: State + ?Sized, C> {
     cap: Capture<T>,
     fd: tokio::io::PollEvented<SelectableFd>,
     codec: C,
 }
 
-impl<T: Activated + ? Sized, C: PacketCodec> PacketStream<T, C> {
+impl<T: Activated + ?Sized, C: PacketCodec> PacketStream<T, C> {
     pub fn new(cap: Capture<T>, fd: RawFd, codec: C) -> Result<PacketStream<T, C>, Error> {
-        Ok(PacketStream { cap, fd: tokio::io::PollEvented::new(SelectableFd { fd })?, codec })
+        Ok(PacketStream {
+            cap,
+            fd: tokio::io::PollEvented::new(SelectableFd { fd })?,
+            codec,
+        })
     }
 }
 
-impl<'a, T: Activated + ? Sized + Unpin, C: PacketCodec + Unpin> futures::Stream for PacketStream<T, C> {
+impl<'a, T: Activated + ?Sized + Unpin, C: PacketCodec + Unpin> futures::Stream
+    for PacketStream<T, C>
+{
     type Item = Result<C::Type, Error>;
-    fn poll_next(self: Pin<&mut Self>, cx: &mut core::task::Context) -> futures::task::Poll<Option<Self::Item>> {
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context,
+    ) -> futures::task::Poll<Option<Self::Item>> {
         let stream = Pin::into_inner(self);
         let p = match stream.cap.next_noblock(cx, &mut stream.fd) {
             Ok(t) => t,


### PR DESCRIPTION
Added a formatting check to CI and formatted the code using `rustfmt`. Default settings for now.

Closes #142 