### PR TITLE
examples/getdevices.rs just lists devices

### DIFF
--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -3,6 +3,8 @@ fn main() {
     for device in pcap::Device::list().unwrap() {
         println!("Found device! {:?}", device);
 
+    /*   capture code commented out
+     *   to prevent waiting forever on device with no traffic
         // now you can create a Capture with this Device if you want.
         let mut cap = pcap::Capture::from_device(device)
             .unwrap()
@@ -14,5 +16,6 @@ fn main() {
         let packet = cap.next();
 
         println!("got a packet! {:?}", packet);
+     */
     }
 }


### PR DESCRIPTION
Commented out the capture code to prevent hang on no traffic devices.
So getdevices executable is closer to description of pcap project
feature list devices.