### PR TITLE
examples/getdevices.rs  now just lists devices

### DIFF
--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -4,15 +4,6 @@ fn main() {
         println!("Found device! {:?}", device);
 
         // now you can create a Capture with this Device if you want.
-        let mut cap = pcap::Capture::from_device(device)
-            .unwrap()
-            .immediate_mode(true)
-            .open()
-            .unwrap();
-
-        // get a packet from this capture
-        let packet = cap.next();
-
-        println!("got a packet! {:?}", packet);
+        // see example/easylisten.rs for how
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -44,7 +44,7 @@ impl Evented for SelectableFd {
 
 pub trait PacketCodec {
     type Type;
-    fn decode<'a>(&mut self, packet: Packet<'a>) -> Result<Self::Type, Error>;
+    fn decode(&mut self, packet: Packet) -> Result<Self::Type, Error>;
 }
 
 pub struct PacketStream<T: State + ?Sized, C> {


### PR DESCRIPTION
Replaced capture code with a pointer to a "how to".  Reason for not
doing a capture on each device, is because it waits forever on devices
without network traffic.

This change also makes the example competable with the project feature of
"list devices".