### PR TITLE
Support for flushing pcap captures to disk

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1143,8 +1143,8 @@ impl Savefile {
 }
 
 impl Savefile {
-    pub fn flush<T>(&mut self, cap: &Capture<T>) -> Result<(), Error> 
-    where 
+    pub fn flush<T>(&mut self, cap: &Capture<T>) -> Result<(), Error>
+    where
         T: State + ?Sized,
     {
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1144,7 +1144,8 @@ impl Savefile {
 
 impl Savefile {
     pub fn flush<T>(&mut self, cap: &Capture<T>) -> Result<(), Error> 
-where T: State + ?Sized
+    where 
+        T: State + ?Sized
     {
         unsafe {
             if raw::pcap_dump_flush(*self.handle) == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1148,9 +1148,9 @@ where T: State + ?Sized
     {
         unsafe {
             if raw::pcap_dump_flush(*self.handle) == 0 {
-                return Ok(());
+                Ok(())
             } else {
-                return Err(Error::new(raw::pcap_geterr(*cap.handle)));
+                Err(Error::new(raw::pcap_geterr(*cap.handle)))
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1142,6 +1142,20 @@ impl Savefile {
     }
 }
 
+impl Savefile {
+    pub fn flush<T>(&mut self, cap: &Capture<T>) -> Result<(), Error> 
+where T: State + ?Sized
+    {
+        unsafe {
+            if raw::pcap_dump_flush(*self.handle) == 0 {
+                return Ok(());
+            } else {
+                return Err(Error::new(raw::pcap_geterr(*cap.handle)));
+            }
+        }
+    }
+}
+
 impl Drop for Savefile {
     fn drop(&mut self) {
         unsafe { raw::pcap_dump_close(*self.handle) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1145,7 +1145,7 @@ impl Savefile {
 impl Savefile {
     pub fn flush<T>(&mut self, cap: &Capture<T>) -> Result<(), Error> 
     where 
-        T: State + ?Sized
+        T: State + ?Sized,
     {
         unsafe {
             if raw::pcap_dump_flush(*self.handle) == 0 {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -151,7 +151,7 @@ extern "C" {
     pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE) -> *mut pcap_dumper_t;
     // pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut FILE;
     // pub fn pcap_dump_ftell(arg1: *mut pcap_dumper_t) -> c_long;
-    // pub fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> c_int;
+    pub fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> c_int;
     pub fn pcap_dump_close(arg1: *mut pcap_dumper_t);
     pub fn pcap_dump(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar);
     pub fn pcap_findalldevs(arg1: *mut *mut pcap_if_t, arg2: *mut c_char) -> c_int;


### PR DESCRIPTION
It's useful to be able to flush a pcap capture to disk. The patch provides support for this through Savefile.