### PR TITLE
generate optimized BPF program by default

### DIFF
--- a/examples/listenlocalhost.rs
+++ b/examples/listenlocalhost.rs
@@ -8,7 +8,7 @@ fn main() {
         .unwrap();
 
     // filter out all packets that don't have 127.0.0.1 as a source or destination.
-    cap.filter("host 127.0.0.1").unwrap();
+    cap.filter("host 127.0.0.1", true).unwrap();
 
     while let Ok(packet) = cap.next() {
         println!("got packet! {:?}", packet);

--- a/examples/nfbpfcompile.rs
+++ b/examples/nfbpfcompile.rs
@@ -32,7 +32,7 @@ fn main() {
     };
 
     let capture = Capture::dead(lt).unwrap();
-    let program: BpfProgram = match capture.compile(&prog) {
+    let program: BpfProgram = match capture.compile(&prog, true) {
         Ok(p) => p,
         Err(e) => {
             println!("{:?}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1023,10 +1023,12 @@ impl<T: Activated + ?Sized> Capture<T> {
         unsafe {
             let mut bpf_program: raw::bpf_program = mem::zeroed();
             let ret = raw::pcap_compile(
-                *self.handle, 
-                &mut bpf_program, 
-                program.as_ptr(), 
-                optimize as libc::c_int, 0);
+                *self.handle,
+                &mut bpf_program,
+                program.as_ptr(),
+                optimize as libc::c_int,
+                0,
+            );
             self.check_err(ret != -1)?;
             let ret = raw::pcap_setfilter(*self.handle, &mut bpf_program);
             raw::pcap_freecode(&mut bpf_program);
@@ -1084,11 +1086,15 @@ impl Capture<Dead> {
 
         unsafe {
             let mut bpf_program: raw::bpf_program = mem::zeroed();
-            if -1 == raw::pcap_compile(
-                *self.handle, 
-                &mut bpf_program, 
-                program.as_ptr(), 
-                optimize as libc::c_int, 0) {
+            if -1
+                == raw::pcap_compile(
+                    *self.handle,
+                    &mut bpf_program,
+                    program.as_ptr(),
+                    optimize as libc::c_int,
+                    0,
+                )
+            {
                 return Err(Error::new(raw::pcap_geterr(*self.handle)));
             }
             Ok(BpfProgram(bpf_program))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1022,7 +1022,7 @@ impl<T: Activated + ?Sized> Capture<T> {
         let program = CString::new(program)?;
         unsafe {
             let mut bpf_program: raw::bpf_program = mem::zeroed();
-            let ret = raw::pcap_compile(*self.handle, &mut bpf_program, program.as_ptr(), 0, 0);
+            let ret = raw::pcap_compile(*self.handle, &mut bpf_program, program.as_ptr(), 1, 0);
             self.check_err(ret != -1)?;
             let ret = raw::pcap_setfilter(*self.handle, &mut bpf_program);
             raw::pcap_freecode(&mut bpf_program);
@@ -1080,7 +1080,7 @@ impl Capture<Dead> {
 
         unsafe {
             let mut bpf_program: raw::bpf_program = mem::zeroed();
-            if -1 == raw::pcap_compile(*self.handle, &mut bpf_program, program.as_ptr(), 0, 0) {
+            if -1 == raw::pcap_compile(*self.handle, &mut bpf_program, program.as_ptr(), 1, 0) {
                 return Err(Error::new(raw::pcap_geterr(*self.handle)));
             }
             Ok(BpfProgram(bpf_program))

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -59,7 +59,7 @@ fn unify_activated() {
     }
 
     fn also_maybe(a: &mut Capture<dyn Activated>) {
-        a.filter("whatever filter string, this won't be run anyway")
+        a.filter("whatever filter string, this won't be run anyway", false)
             .unwrap();
     }
 }
@@ -313,15 +313,29 @@ fn test_compile() {
 
     let bpf_capture = Capture::dead(Linktype::ETHERNET).unwrap();
 
-    let program = bpf_capture.compile("dst host 8.8.8.8").unwrap();
+    let program = bpf_capture.compile("dst host 8.8.8.8", false).unwrap();
     let instructions = program.get_instructions();
 
     assert!(instructions.len() > 0);
     assert!(program.filter(packet.data));
 
-    let program = bpf_capture.compile("src host 8.8.8.8").unwrap();
+    let program = bpf_capture.compile("src host 8.8.8.8", false).unwrap();
     let instructions = program.get_instructions();
 
     assert!(instructions.len() > 0);
     assert!(!program.filter(packet.data));
+}
+
+#[test]
+fn test_compile_optimized() {
+    let bpf_capture = Capture::dead(Linktype::ETHERNET).unwrap();
+
+    let program_str = "ip and ip and tcp";
+    let program_unopt = bpf_capture.compile(program_str, false).unwrap();
+    let instr_unopt = program_unopt.get_instructions();
+
+    let program_opt = bpf_capture.compile(program_str, true).unwrap();
+    let instr_opt = program_opt.get_instructions();
+
+    assert!(instr_opt.len() < instr_unopt.len());
 }


### PR DESCRIPTION
tcpdump by default optimizes the generated bpf program, and I figured this crate should provide similar functionality.

An alternative could be to expose a parameter to the filter() and compile() methods to specify whether you want optimized programs.