### PR TITLE
Tell Tokio that pcap file descriptor is read-only

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -57,7 +57,7 @@ impl<T: Activated + ?Sized, C: PacketCodec> PacketStream<T, C> {
     pub fn new(cap: Capture<T>, fd: RawFd, codec: C) -> Result<PacketStream<T, C>, Error> {
         Ok(PacketStream {
             cap,
-            fd: tokio::io::PollEvented::new(SelectableFd { fd })?,
+            fd: tokio::io::PollEvented::new_with_ready(SelectableFd { fd }, mio::Ready::readable())?,
             codec,
         })
     }


### PR DESCRIPTION
Fixes #90, where the `streamlisten` example fails on Mac OS. 

This fix comes from [this comment](https://github.com/tokio-rs/tokio/issues/2413#issuecomment-616019772) on https://github.com/tokio-rs/tokio/issues/2413. It looks like the issue is that the pcap file descriptor is read-only, but PollEvented by default expects it to be read-write, so it raises an error.

I've tested that with this change, the `streamlisten` example works on Mac, and that without it I get an `InvalidInput` error when running that example.