### PR TITLE
Added support for device addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ errno = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 widestring = "0.2"
+winapi = {version = "0.3", features = ["ws2def", "ws2ipdef"]} 
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ use std::fmt;
 use std::io;
 use std::marker::PhantomData;
 use std::mem;
+use std::net::IpAddr;
 use std::ops::Deref;
 #[cfg(not(windows))]
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -66,6 +67,12 @@ use self::Error::*;
 
 #[cfg(target_os = "windows")]
 use widestring::WideCString;
+
+#[cfg(target_os = "windows")]
+use winapi::shared::{
+    ws2def::{AF_INET, AF_INET6, SOCKADDR_IN},
+    ws2ipdef::SOCKADDR_IN6
+};
 
 mod raw;
 #[cfg(feature = "capture-stream")]
@@ -189,11 +196,17 @@ pub struct Device {
     pub name: String,
     /// A textual description of the interface, if available
     pub desc: Option<String>,
+    /// Addresses assocated with this interface
+    pub addresses: Vec<Address>,
 }
 
 impl Device {
-    fn new(name: String, desc: Option<String>) -> Device {
-        Device { name, desc }
+    fn new(name: String, desc: Option<String>, addresses: Vec<Address>) -> Device {
+        Device {
+            name,
+            desc,
+            addresses,
+        }
     }
 
     /// Opens a `Capture<Active>` on this device.
@@ -207,7 +220,7 @@ impl Device {
     pub fn lookup() -> Result<Device, Error> {
         with_errbuf(|err| unsafe {
             cstr_to_string(raw::pcap_lookupdev(err))?
-                .map(|name| Device::new(name, None))
+                .map(|name| Device::new(name, None, Vec::new()))
                 .ok_or_else(|| Error::new(err))
         })
     }
@@ -215,7 +228,7 @@ impl Device {
     pub fn lookup() -> Result<Device, Error> {
         with_errbuf(|err| unsafe {
             wstr_to_string(raw::pcap_lookupdev(err))?
-                .map(|name| Device::new(name, None))
+                .map(|name| Device::new(name, None, Vec::new()))
                 .ok_or_else(|| Error::new(err))
         })
     }
@@ -235,6 +248,7 @@ impl Device {
                     devices.push(Device::new(
                         cstr_to_string(dev.name)?.ok_or(InvalidString)?,
                         cstr_to_string(dev.description)?,
+                        Address::new_vec(dev.addresses),
                     ));
                     cur = dev.next;
                 }
@@ -248,7 +262,89 @@ impl Device {
 
 impl From<&str> for Device {
     fn from(name: &str) -> Self {
-        Device::new(name.into(), None)
+        Device::new(name.into(), None, Vec::new())
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Address information for an interface
+pub struct Address {
+    /// The address
+    pub addr: IpAddr,
+    /// Network mask for this address
+    pub netmask: Option<IpAddr>,
+    /// Broadcast address for this address
+    pub broadcast_addr: Option<IpAddr>,
+    /// P2P destination address for this address
+    pub dst_addr: Option<IpAddr>,
+}
+
+impl Address {
+    unsafe fn new_vec(mut ptr: *const raw::pcap_addr_t) -> Vec<Address> {
+        let mut vec = Vec::new();
+        while !ptr.is_null() {
+            if let Some(addr) = Address::new(ptr) {
+                vec.push(addr);
+            }
+            ptr = (*ptr).next;
+        }
+        vec
+    }
+
+    unsafe fn new(ptr: *const raw::pcap_addr_t) -> Option<Address> {
+        if let Some(addr) = Self::convert_sockaddr((*ptr).addr) {
+            Some(Address {
+                addr,
+                netmask: Self::convert_sockaddr((*ptr).netmask),
+                broadcast_addr: Self::convert_sockaddr((*ptr).broadaddr),
+                dst_addr: Self::convert_sockaddr((*ptr).dstaddr),
+            })
+        } else {
+            None
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    unsafe fn convert_sockaddr(ptr: *const libc::sockaddr) -> Option<IpAddr> {
+        if ptr.is_null() {
+            return None;
+        }
+
+        match (*ptr).sa_family as i32 {
+            libc::AF_INET => {
+                let ptr: *const libc::sockaddr_in = std::mem::transmute(ptr);
+                Some(IpAddr::V4(u32::from_be((*ptr).sin_addr.s_addr).into()))
+            }
+
+            libc::AF_INET6 => {
+                let ptr: *const libc::sockaddr_in6 = std::mem::transmute(ptr);
+                Some(IpAddr::V6((*ptr).sin6_addr.s6_addr.into()))
+            }
+
+            _ => None,
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    unsafe fn convert_sockaddr(ptr: *const libc::sockaddr) -> Option<IpAddr> {
+        if ptr.is_null() {
+            return None;
+        }
+
+        match (*ptr).sa_family as i32 {
+            AF_INET => {
+                let ptr: *const SOCKADDR_IN = std::mem::transmute(ptr);
+                let addr : [u8;4] = std::mem::transmute(*(*ptr).sin_addr.S_un.S_addr());
+                Some(IpAddr::from(addr))
+            }
+            AF_INET6 => {
+                let ptr: *const SOCKADDR_IN6 = std::mem::transmute(ptr);
+                let addr = *(*ptr).sin6_addr.u.Byte();
+                Some(IpAddr::from(addr))
+            }
+
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
This adds an `addresses` field to the Device struct, exposing the underlying `addresses` field from `pcap_if_t`. Ipv4 and Ipv6 addresses are supported.