### PR TITLE
Fix latest clippy warnings and other issues

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,16 +18,16 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.40.0", "1.45.0", stable, beta]
+        toolchain: ["1.40.0", "1.47.0", stable, beta]
         profile: ['', --release]
         features: ['', '--features full']
         exclude:
           - os: windows-latest
             features: '--features full'
-          # Tokio 1.0 (and thus capture-stream) requires 1.45; do not run on 1.40
+          # Tokio 1.0 (and thus capture-stream) requires 1.47; do not run on 1.40
           - toolchain: "1.40.0"
             features: '--features full'
-          - toolchain: "1.45.0"
+          - toolchain: "1.47.0"
             features: ''
         include:
           # nightly check is performed on ubuntu only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Add support for device addresses.
+- `capture-stream` requires rustc version 1.47.0 due to dependency on `tokio`.
 
 ## [0.9.0] - 2021-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `capture-stream` requires rustc version 1.47.0 due to dependency on `tokio`.
+
 ## [0.9.1] - 2021-11-07
 
 ### Added
 
 - Add support for device addresses.
-- `capture-stream` requires rustc version 1.47.0 due to dependency on `tokio`.
 
 ## [0.9.0] - 2021-09-05
 
@@ -19,7 +22,6 @@
 
 - Updated dependency `tokio` from version 0.2 to 1.0
 - `capture-stream` requires rustc version 1.45.0 due to dependency on `tokio`.
-
 
 ## [0.8.1] - 2020-12-30
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ As of 0.8.0 this crate uses Rust 2018 and requires a compiler version >= 1.40.0.
 
 As of 0.9.0 the `capture-stream` feature requires a compiler version >= 1.45.0.
 
+As of 0.9.2 the `capture-stream` feature requires a compiler version >= 1.47.0.
+
 ## Windows
 
 Install [WinPcap](http://www.winpcap.org/install/default.htm).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@ impl Address {
         match (*ptr).sa_family as i32 {
             AF_INET => {
                 let ptr: *const SOCKADDR_IN = std::mem::transmute(ptr);
-                let addr: [u8; 4] = std::mem::transmute(*(*ptr).sin_addr.S_un.S_addr());
+                let addr: [u8; 4] = (*(*ptr).sin_addr.S_un.S_addr()).to_ne_bytes();
                 Some(IpAddr::from(addr))
             }
             AF_INET6 => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -626,27 +626,27 @@ pub enum Dead {}
 /// may or may not have particular capabilities. This trait is implemented by phantom
 /// types which allows us to punt these invariants to the type system to avoid runtime
 /// errors.
-pub unsafe trait Activated: State {}
+pub trait Activated: State {}
 
-unsafe impl Activated for Active {}
+impl Activated for Active {}
 
-unsafe impl Activated for Offline {}
+impl Activated for Offline {}
 
-unsafe impl Activated for Dead {}
+impl Activated for Dead {}
 
 /// `Capture`s can be in different states at different times, and in these states they
 /// may or may not have particular capabilities. This trait is implemented by phantom
 /// types which allows us to punt these invariants to the type system to avoid runtime
 /// errors.
-pub unsafe trait State {}
+pub trait State {}
 
-unsafe impl State for Inactive {}
+impl State for Inactive {}
 
-unsafe impl State for Active {}
+impl State for Active {}
 
-unsafe impl State for Offline {}
+impl State for Offline {}
 
-unsafe impl State for Dead {}
+impl State for Dead {}
 
 /// This is a pcap capture handle which is an abstraction over the `pcap_t` provided by pcap.
 /// There are many ways to instantiate and interact with a pcap handle, so phantom types are


### PR DESCRIPTION
Clippy was complaining that unsafe traits need to be documented. I couldn't figure out why they are unsafe so I made them safe and let's see if it works.

Then there were a few other issues to fix. Amongst other things tokio now requires rustc 1.47.